### PR TITLE
fix: remove unnecessary lowerCase transformation in AMF IDs

### DIFF
--- a/demo/APIC-349-cache-resolution.json
+++ b/demo/APIC-349-cache-resolution.json
@@ -1,0 +1,16252 @@
+[
+  {
+    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml",
+    "@type": [
+      "http://a.ml/vocabularies/document#Document",
+      "http://a.ml/vocabularies/document#Fragment",
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/document#encodes": [
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api",
+        "@type": [
+          "http://a.ml/vocabularies/apiContract#WebAPI",
+          "http://a.ml/vocabularies/document#RootDomainElement",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "testExamples"
+          }
+        ],
+        "http://a.ml/vocabularies/core#description": [
+          {
+            "@value": "Testing examples display"
+          }
+        ],
+        "http://a.ml/vocabularies/core#documentation": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/creative-work/Test%20Console%20and%20Mocking%20Service",
+            "@type": [
+              "http://a.ml/vocabularies/core#CreativeWork",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#title": [
+              {
+                "@value": "Test Console and Mocking Service"
+              }
+            ],
+            "http://a.ml/vocabularies/core#description": [
+              {
+                "@value": "Welcome to the _Test API_ Documentation. The _Test API_\nallows you to test console and mocking service features\n[integration libraries](https://mulesoft.com)\n"
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/creative-work/Legal",
+            "@type": [
+              "http://a.ml/vocabularies/core#CreativeWork",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#title": [
+              {
+                "@value": "Legal"
+              }
+            ],
+            "http://a.ml/vocabularies/core#description": [
+              {
+                "@value": "The API gives you chance to test features referred to API Console and Mocking Service."
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/creative-work/Another%20title",
+            "@type": [
+              "http://a.ml/vocabularies/core#CreativeWork",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#title": [
+              {
+                "@value": "Another title"
+              }
+            ],
+            "http://a.ml/vocabularies/core#description": [
+              {
+                "@value": "this is the content\n"
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/docs/DocumentationItem-1.raml/creative-work/Fragment%20doc%20title",
+            "@type": [
+              "http://a.ml/vocabularies/core#CreativeWork",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#title": [
+              {
+                "@value": "Fragment doc title"
+              }
+            ],
+            "http://a.ml/vocabularies/core#description": [
+              {
+                "@value": "Fragment doc content"
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/apiContract#endpoint": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#EndPoint",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/apiContract#path": [
+              {
+                "@value": "/CASE1"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#supportedOperation": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Operation",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#method": [
+                  {
+                    "@value": "get"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "ExamplesInTypeAndExampleInResponseIncluded"
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#expects": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/request",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Request",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#parameter": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/request/parameter/channel",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Parameter",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "channel"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#paramName": [
+                          {
+                            "@value": "channel"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#description": [
+                          {
+                            "@value": "Channel to fetch history for."
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#required": [
+                          {
+                            "@value": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#binding": [
+                          {
+                            "@value": "query"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/request/parameter/channel/scalar/schema",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "schema"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#description": [
+                              {
+                                "@value": "Channel to fetch history for."
+                              }
+                            ],
+                            "http://a.ml/vocabularies/apiContract#examples": [
+                              {
+                                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/request/parameter/channel/scalar/schema/example/default-example",
+                                "@type": [
+                                  "http://a.ml/vocabularies/apiContract#Example",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/document#strict": [
+                                  {
+                                    "@value": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document#structuredValue": [
+                                  {
+                                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/request/parameter/channel/scalar/schema/example/default-example/scalar_1",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/data#Scalar",
+                                      "http://a.ml/vocabularies/data#Node",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/data#value": [
+                                      {
+                                        "@value": "C1234567890"
+                                      }
+                                    ],
+                                    "http://www.w3.org/ns/shacl#datatype": [
+                                      {
+                                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/core#name": [
+                                      {
+                                        "@value": "scalar_1"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document#raw": [
+                                  {
+                                    "@value": "C1234567890"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/request/parameter/channel/scalar/schema/example/default-example/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                                      {
+                                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/request/parameter/channel/scalar/schema/example/default-example/source-map/tracked-element/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/request/parameter/channel/scalar/schema/example/default-example"
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/request/parameter/channel"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#returns": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Response",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/json"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/link--378888626",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "LibObjectWithExamples"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#EndPoint",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/apiContract#path": [
+              {
+                "@value": "/CASE2"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#supportedOperation": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Operation",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#method": [
+                  {
+                    "@value": "get"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "NoExamplesInTypeAndExampleInResponseIncluded"
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#expects": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/request",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Request",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#parameter": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/request/parameter/channel",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Parameter",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "channel"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#paramName": [
+                          {
+                            "@value": "channel"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#description": [
+                          {
+                            "@value": "Channel to fetch history for."
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#required": [
+                          {
+                            "@value": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#binding": [
+                          {
+                            "@value": "query"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/request/parameter/channel/scalar/schema",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "schema"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#description": [
+                              {
+                                "@value": "Channel to fetch history for."
+                              }
+                            ],
+                            "http://a.ml/vocabularies/apiContract#examples": [
+                              {
+                                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/request/parameter/channel/scalar/schema/example/default-example",
+                                "@type": [
+                                  "http://a.ml/vocabularies/apiContract#Example",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/document#strict": [
+                                  {
+                                    "@value": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document#structuredValue": [
+                                  {
+                                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/request/parameter/channel/scalar/schema/example/default-example/scalar_1",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/data#Scalar",
+                                      "http://a.ml/vocabularies/data#Node",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/data#value": [
+                                      {
+                                        "@value": "C1234567890"
+                                      }
+                                    ],
+                                    "http://www.w3.org/ns/shacl#datatype": [
+                                      {
+                                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/core#name": [
+                                      {
+                                        "@value": "scalar_1"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document#raw": [
+                                  {
+                                    "@value": "C1234567890"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/request/parameter/channel/scalar/schema/example/default-example/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                                      {
+                                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/request/parameter/channel/scalar/schema/example/default-example/source-map/tracked-element/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/request/parameter/channel/scalar/schema/example/default-example"
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/request/parameter/channel"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#returns": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Response",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/json"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/link--810007852",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "UsingObj"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#EndPoint",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/apiContract#path": [
+              {
+                "@value": "/CASE3"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#supportedOperation": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Operation",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#method": [
+                  {
+                    "@value": "get"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "ExamplesInTypeAndExamplesInResponse"
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#expects": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/request",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Request",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#parameter": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/request/parameter/channel",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Parameter",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "channel"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#paramName": [
+                          {
+                            "@value": "channel"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#description": [
+                          {
+                            "@value": "Channel to fetch history for."
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#required": [
+                          {
+                            "@value": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#binding": [
+                          {
+                            "@value": "query"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/request/parameter/channel/scalar/schema",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "schema"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#description": [
+                              {
+                                "@value": "Channel to fetch history for."
+                              }
+                            ],
+                            "http://a.ml/vocabularies/apiContract#examples": [
+                              {
+                                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/request/parameter/channel/scalar/schema/example/default-example",
+                                "@type": [
+                                  "http://a.ml/vocabularies/apiContract#Example",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/document#strict": [
+                                  {
+                                    "@value": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document#structuredValue": [
+                                  {
+                                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/request/parameter/channel/scalar/schema/example/default-example/scalar_1",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/data#Scalar",
+                                      "http://a.ml/vocabularies/data#Node",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/data#value": [
+                                      {
+                                        "@value": "C1234567890"
+                                      }
+                                    ],
+                                    "http://www.w3.org/ns/shacl#datatype": [
+                                      {
+                                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/core#name": [
+                                      {
+                                        "@value": "scalar_1"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document#raw": [
+                                  {
+                                    "@value": "C1234567890"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/request/parameter/channel/scalar/schema/example/default-example/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                                      {
+                                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/request/parameter/channel/scalar/schema/example/default-example/source-map/tracked-element/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/request/parameter/channel/scalar/schema/example/default-example"
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/request/parameter/channel"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#returns": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Response",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/json"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/link--378888626",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "LibObjectWithExamples"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#EndPoint",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/apiContract#path": [
+              {
+                "@value": "/CASE4"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#supportedOperation": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Operation",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#method": [
+                  {
+                    "@value": "get"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "NoExamplesInTypeAndExamplesInResponseInline"
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#expects": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/request",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Request",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#parameter": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/request/parameter/channel",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Parameter",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "channel"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#paramName": [
+                          {
+                            "@value": "channel"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#description": [
+                          {
+                            "@value": "Channel to fetch history for."
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#required": [
+                          {
+                            "@value": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#binding": [
+                          {
+                            "@value": "query"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/request/parameter/channel/scalar/schema",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "schema"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#description": [
+                              {
+                                "@value": "Channel to fetch history for."
+                              }
+                            ],
+                            "http://a.ml/vocabularies/apiContract#examples": [
+                              {
+                                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/request/parameter/channel/scalar/schema/example/default-example",
+                                "@type": [
+                                  "http://a.ml/vocabularies/apiContract#Example",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/document#strict": [
+                                  {
+                                    "@value": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document#structuredValue": [
+                                  {
+                                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/request/parameter/channel/scalar/schema/example/default-example/scalar_1",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/data#Scalar",
+                                      "http://a.ml/vocabularies/data#Node",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/data#value": [
+                                      {
+                                        "@value": "C1234567890"
+                                      }
+                                    ],
+                                    "http://www.w3.org/ns/shacl#datatype": [
+                                      {
+                                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/core#name": [
+                                      {
+                                        "@value": "scalar_1"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document#raw": [
+                                  {
+                                    "@value": "C1234567890"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/request/parameter/channel/scalar/schema/example/default-example/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                                      {
+                                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/request/parameter/channel/scalar/schema/example/default-example/source-map/tracked-element/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/request/parameter/channel/scalar/schema/example/default-example"
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/request/parameter/channel"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#returns": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Response",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/json"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/link--810007852",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "UsingObj"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#EndPoint",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/apiContract#path": [
+              {
+                "@value": "/CASE5"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#supportedOperation": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Operation",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#method": [
+                  {
+                    "@value": "get"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "Testing No Examples In Type And Examples In Response using include."
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#expects": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/request",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Request",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#parameter": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/request/parameter/channel",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Parameter",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "channel"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#paramName": [
+                          {
+                            "@value": "channel"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#description": [
+                          {
+                            "@value": "Channel to fetch history for."
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#required": [
+                          {
+                            "@value": true
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiContract#binding": [
+                          {
+                            "@value": "query"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/request/parameter/channel/scalar/schema",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "schema"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#description": [
+                              {
+                                "@value": "Channel to fetch history for."
+                              }
+                            ],
+                            "http://a.ml/vocabularies/apiContract#examples": [
+                              {
+                                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/request/parameter/channel/scalar/schema/example/default-example",
+                                "@type": [
+                                  "http://a.ml/vocabularies/apiContract#Example",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/document#strict": [
+                                  {
+                                    "@value": true
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document#structuredValue": [
+                                  {
+                                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/request/parameter/channel/scalar/schema/example/default-example/scalar_1",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/data#Scalar",
+                                      "http://a.ml/vocabularies/data#Node",
+                                      "http://a.ml/vocabularies/document#DomainElement"
+                                    ],
+                                    "http://a.ml/vocabularies/data#value": [
+                                      {
+                                        "@value": "C1234567890"
+                                      }
+                                    ],
+                                    "http://www.w3.org/ns/shacl#datatype": [
+                                      {
+                                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/core#name": [
+                                      {
+                                        "@value": "scalar_1"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document#raw": [
+                                  {
+                                    "@value": "C1234567890"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/request/parameter/channel/scalar/schema/example/default-example/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                                      {
+                                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/request/parameter/channel/scalar/schema/example/default-example/source-map/tracked-element/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/request/parameter/channel/scalar/schema/example/default-example"
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/request/parameter/channel"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#returns": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Response",
+                      "http://a.ml/vocabularies/apiContract#Message",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/apiContract#payload": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Payload",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/core#mediaType": [
+                          {
+                            "@value": "application/json"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schema": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/link--810007852",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#NodeShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/document#link-target": [
+                              {
+                                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document#link-label": [
+                              {
+                                "@value": "UsingObj"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#version": [
+      {
+        "@value": "2.0.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document#references": [
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example.json",
+        "@type": [
+          "http://a.ml/vocabularies/document#ExternalFragment",
+          "http://a.ml/vocabularies/document#Fragment",
+          "http://a.ml/vocabularies/document#Unit"
+        ],
+        "http://a.ml/vocabularies/document#encodes": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example.json#/external",
+            "@type": [
+              "http://a.ml/vocabularies/document#ExternalDomainElement",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "{\n  \"ok\" : true ,\n  \"channel\" : {\n    \"id\" : \"C024BE91L\" ,\n    \"name\" : \"fun\" ,\n    \"created\" : \"1360782804\" ,\n    \"creator\" : \"U024BE7LH\" ,\n    \"is_archived\" : false ,\n    \"is_general\" : false ,\n    \"is_member\" : true ,\n    \"members\" : \"\" ,\n    \"topic\" : \"\" ,\n    \"purpose\" : \"\" ,\n    \"last_read\" : \"1401383885.000061\" ,\n    \"latest\" : \"\" ,\n    \"unread_count\" : 0,\n    \"owner\" : \"Caro\" \n  }\n}"
+              }
+            ],
+            "http://a.ml/vocabularies/core#mediaType": [
+              {
+                "@value": "application/json"
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#version": [
+          {
+            "@value": "2.0.0"
+          }
+        ],
+        "http://a.ml/vocabularies/document#root": [
+          {
+            "@value": false
+          }
+        ]
+      },
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json",
+        "@type": [
+          "http://a.ml/vocabularies/document#ExternalFragment",
+          "http://a.ml/vocabularies/document#Fragment",
+          "http://a.ml/vocabularies/document#Unit"
+        ],
+        "http://a.ml/vocabularies/document#encodes": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json#/external",
+            "@type": [
+              "http://a.ml/vocabularies/document#ExternalDomainElement",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "{\n  \"ok\" : true ,\n  \"channel\" : {\n    \"id\" : \"LLLLSSS\" ,\n    \"name\" : \"fun\" ,\n    \"created\" : \"1360782804\" ,\n    \"creator\" : \"LLL\" ,\n    \"is_archived\" : false ,\n    \"is_general\" : false ,\n    \"is_member\" : true ,\n    \"members\" : \"\" ,\n    \"topic\" : \"\" ,\n    \"purpose\" : \"\" ,\n    \"last_read\" : \"1401383885.000061\" ,\n    \"latest\" : \"\" ,\n    \"unread_count\" : 0,\n    \"owner\" : \"Nati\" \n  }\n}"
+              }
+            ],
+            "http://a.ml/vocabularies/core#mediaType": [
+              {
+                "@value": "application/json"
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#version": [
+          {
+            "@value": "2.0.0"
+          }
+        ],
+        "http://a.ml/vocabularies/document#root": [
+          {
+            "@value": false
+          }
+        ]
+      },
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/docs/api.md",
+        "@type": [
+          "http://a.ml/vocabularies/document#ExternalFragment",
+          "http://a.ml/vocabularies/document#Fragment",
+          "http://a.ml/vocabularies/document#Unit"
+        ],
+        "http://a.ml/vocabularies/document#encodes": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/docs/api.md#/external",
+            "@type": [
+              "http://a.ml/vocabularies/document#ExternalDomainElement",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "The API gives you chance to test features referred to API Console and Mocking Service."
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#version": [
+          {
+            "@value": "2.0.0"
+          }
+        ],
+        "http://a.ml/vocabularies/document#root": [
+          {
+            "@value": false
+          }
+        ]
+      },
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/docs/DocumentationItem-1.raml",
+        "@type": [
+          "http://a.ml/vocabularies/apiContract#UserDocumentationFragment",
+          "http://a.ml/vocabularies/document#Fragment",
+          "http://a.ml/vocabularies/document#Unit"
+        ],
+        "http://a.ml/vocabularies/document#encodes": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/docs/DocumentationItem-1.raml/creative-work/Fragment%20doc%20title",
+            "@type": [
+              "http://a.ml/vocabularies/core#CreativeWork",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#title": [
+              {
+                "@value": "Fragment doc title"
+              }
+            ],
+            "http://a.ml/vocabularies/core#description": [
+              {
+                "@value": "Fragment doc content"
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#version": [
+          {
+            "@value": "2.0.0"
+          }
+        ],
+        "http://a.ml/vocabularies/document#root": [
+          {
+            "@value": false
+          }
+        ]
+      },
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml",
+        "@type": [
+          "http://a.ml/vocabularies/document#Module",
+          "http://a.ml/vocabularies/document#Unit"
+        ],
+        "http://a.ml/vocabularies/document#declares": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#closed": [
+              {
+                "@value": false
+              }
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/channel",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#channel"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#NodeShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#closed": [
+                      {
+                        "@value": false
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#property": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#purpose"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose/scalar/purpose",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "purpose"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "purpose"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#owner"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner/scalar/owner",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "owner"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 1
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "owner"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_member"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member/scalar/is_member",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_member"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_member"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_archived"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived/scalar/is_archived",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_archived"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_archived"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name/scalar/name",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "name"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "name"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#unread_count"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count/scalar/unread_count",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://a.ml/vocabularies/shapes#number"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "unread_count"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "unread_count"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#created"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created/scalar/created",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "created"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "created"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#id"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id/scalar/id",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "id"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "id"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#topic"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic/scalar/topic",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "topic"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "topic"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#latest"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest/scalar/latest",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "latest"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "latest"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#last_read"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read/scalar/last_read",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "last_read"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "last_read"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#members"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members/scalar/members",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "members"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "members"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#creator"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator/scalar/creator",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "creator"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "creator"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_general"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general/scalar/is_general",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_general"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_general"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "ExtendingObj"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "channel"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#ok"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok/scalar/ok",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "ok"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ok"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "LibObjectWithExamples"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#examples": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo1",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "ChannelInfo1"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo1/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo1/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo1/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo1/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "channel info 1"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#raw": [
+                  {
+                    "@value": "ok: false\nchannel:\n  owner: \"channel info 1\""
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "ChannelInfo2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "pp"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "channel info 2"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#raw": [
+                  {
+                    "@value": "ok: true\nchannel:\n  owner: \"pp\"\n  id: \"channel info 2\""
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "example_0"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "LLLLSSS"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#name": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "fun"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#created": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_6",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1360782804"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_6"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#creator": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_7",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "LLL"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_7"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_archived": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_8",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_8"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_general": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_9",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_9"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_member": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_10",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "true"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_10"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#members": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_11",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_11"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#topic": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_12",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_12"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#purpose": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_13",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_13"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#last_read": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_14",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1401383885.000061"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_14"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#latest": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_15",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_15"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#unread_count": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_16",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "0"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_16"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_17",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "Nati"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_17"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#reference-id": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json#/external"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#location": [
+                  {
+                    "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/source-map/tracked-element/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "example1"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "ex1"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "A"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#raw": [
+                  {
+                    "@value": "ok: true\nchannel:\n  id: \"ex1\"\n  owner: \"A\""
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/source-map/tracked-element/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "example2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "ex2"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "B"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#raw": [
+                  {
+                    "@value": "ok: false\nchannel:\n  id: \"ex2\"\n  owner: \"B\""
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/source-map/tracked-element/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#closed": [
+              {
+                "@value": false
+              }
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#ok"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok/scalar/ok",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "ok"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ok"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/channel",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#channel"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#NodeShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#closed": [
+                      {
+                        "@value": false
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#property": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#purpose"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose/scalar/purpose",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "purpose"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "purpose"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#owner"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner/scalar/owner",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "owner"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 1
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "owner"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_member"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member/scalar/is_member",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_member"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_member"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_archived"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived/scalar/is_archived",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_archived"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_archived"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name/scalar/name",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "name"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "name"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#unread_count"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count/scalar/unread_count",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://a.ml/vocabularies/shapes#number"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "unread_count"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "unread_count"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#created"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created/scalar/created",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "created"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "created"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#id"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id/scalar/id",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "id"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "id"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#topic"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic/scalar/topic",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "topic"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "topic"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#latest"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest/scalar/latest",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "latest"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "latest"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#last_read"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read/scalar/last_read",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "last_read"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "last_read"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#members"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members/scalar/members",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "members"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "members"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#creator"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator/scalar/creator",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "creator"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "creator"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_general"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general/scalar/is_general",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_general"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_general"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "ExtendingObj"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "channel"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "UsingObj"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#examples": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "example_0"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "LLLLSSS"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#name": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "fun"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#created": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_6",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1360782804"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_6"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#creator": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_7",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "LLL"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_7"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_archived": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_8",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_8"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_general": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_9",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_9"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_member": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_10",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "true"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_10"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#members": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_11",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_11"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#topic": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_12",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_12"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#purpose": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_13",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_13"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#last_read": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_14",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1401383885.000061"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_14"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#latest": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_15",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_15"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#unread_count": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_16",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "0"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_16"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_17",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "Nati"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_17"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#reference-id": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json#/external"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#location": [
+                  {
+                    "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/source-map/tracked-element/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "example1"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "ex1"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "A"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#raw": [
+                  {
+                    "@value": "ok: true\nchannel:\n  id: \"ex1\"\n  owner: \"A\""
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/source-map/tracked-element/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "example2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "ex2"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "B"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#raw": [
+                  {
+                    "@value": "ok: false\nchannel:\n  id: \"ex2\"\n  owner: \"B\""
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/source-map/tracked-element/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "example_1"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "C024BE91L"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#name": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "fun"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#created": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_6",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1360782804"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_6"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#creator": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_7",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "U024BE7LH"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_7"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_archived": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_8",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_8"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_general": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_9",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_9"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_member": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_10",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "true"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_10"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#members": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_11",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_11"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#topic": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_12",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_12"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#purpose": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_13",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_13"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#last_read": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_14",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1401383885.000061"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_14"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#latest": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_15",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_15"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#unread_count": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_16",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "0"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_16"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_17",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "Caro"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_17"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#reference-id": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example.json#/external"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#location": [
+                  {
+                    "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example.json"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/source-map/tracked-element/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "example_2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "LLLLSSS"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#name": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "fun"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#created": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_6",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1360782804"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_6"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#creator": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_7",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "LLL"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_7"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_archived": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_8",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_8"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_general": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_9",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_9"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_member": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_10",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "true"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_10"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#members": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_11",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_11"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#topic": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_12",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_12"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#purpose": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_13",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_13"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#last_read": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_14",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1401383885.000061"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_14"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#latest": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_15",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_15"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#unread_count": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_16",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "0"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_16"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_17",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "Nati"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_17"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#reference-id": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json#/external"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#location": [
+                  {
+                    "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/source-map/tracked-element/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#closed": [
+              {
+                "@value": false
+              }
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#id"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id/scalar/id",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "id"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "id"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name/scalar/name",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "name"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "name"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#created"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created/scalar/created",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "created"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "created"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#creator"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator/scalar/creator",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "creator"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "creator"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#is_archived"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived/scalar/is_archived",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_archived"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "is_archived"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#is_general"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general/scalar/is_general",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_general"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "is_general"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#is_member"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member/scalar/is_member",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_member"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "is_member"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#members"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members/scalar/members",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "members"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "members"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#topic"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic/scalar/topic",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "topic"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "topic"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#purpose"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose/scalar/purpose",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "purpose"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "purpose"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#last_read"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read/scalar/last_read",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "last_read"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "last_read"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#latest"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest/scalar/latest",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "latest"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "latest"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#unread_count"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count/scalar/unread_count",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://a.ml/vocabularies/shapes#number"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "unread_count"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "unread_count"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "BaseObj"
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExample",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#closed": [
+              {
+                "@value": false
+              }
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/channel",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#channel"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#NodeShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#closed": [
+                      {
+                        "@value": false
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#property": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#purpose"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose/scalar/purpose",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "purpose"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "purpose"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#owner"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner/scalar/owner",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "owner"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 1
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "owner"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_member"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member/scalar/is_member",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_member"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_member"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_archived"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived/scalar/is_archived",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_archived"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_archived"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name/scalar/name",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "name"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "name"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#unread_count"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count/scalar/unread_count",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://a.ml/vocabularies/shapes#number"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "unread_count"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "unread_count"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#created"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created/scalar/created",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "created"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "created"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#id"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id/scalar/id",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "id"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "id"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#topic"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic/scalar/topic",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "topic"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "topic"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#latest"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest/scalar/latest",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "latest"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "latest"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#last_read"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read/scalar/last_read",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "last_read"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "last_read"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#members"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members/scalar/members",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "members"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "members"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#creator"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator/scalar/creator",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "creator"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "creator"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_general"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general/scalar/is_general",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_general"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_general"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "ExtendingObj"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "channel"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#ok"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok/scalar/ok",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "ok"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ok"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "LibObjectWithExample"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#examples": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExample/example/default-example",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExample/example/default-example/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExample/example/default-example/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExample/example/default-example/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExample/example/default-example/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "single"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#raw": [
+                  {
+                    "@value": "ok: false\nchannel:\n  owner: \"single\""
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#closed": [
+              {
+                "@value": false
+              }
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#purpose"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose/scalar/purpose",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "purpose"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "purpose"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#owner"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner/scalar/owner",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "owner"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "owner"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#is_member"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member/scalar/is_member",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_member"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "is_member"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#is_archived"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived/scalar/is_archived",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_archived"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "is_archived"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name/scalar/name",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "name"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "name"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#unread_count"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count/scalar/unread_count",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://a.ml/vocabularies/shapes#number"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "unread_count"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "unread_count"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#created"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created/scalar/created",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "created"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "created"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#id"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id/scalar/id",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "id"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "id"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#topic"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic/scalar/topic",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "topic"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "topic"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#latest"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest/scalar/latest",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "latest"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "latest"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#last_read"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read/scalar/last_read",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "last_read"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "last_read"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#members"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members/scalar/members",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "members"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "members"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#creator"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator/scalar/creator",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "creator"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "creator"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#is_general"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general/scalar/is_general",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_general"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "is_general"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "ExtendingObj"
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#closed": [
+              {
+                "@value": false
+              }
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/channel",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#channel"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#NodeShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#closed": [
+                      {
+                        "@value": false
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#property": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#purpose"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose/scalar/purpose",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "purpose"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "purpose"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#owner"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner/scalar/owner",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "owner"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 1
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "owner"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_member"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member/scalar/is_member",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_member"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_member"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_archived"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived/scalar/is_archived",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_archived"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_archived"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name/scalar/name",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "name"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "name"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#unread_count"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count/scalar/unread_count",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://a.ml/vocabularies/shapes#number"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "unread_count"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "unread_count"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#created"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created/scalar/created",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "created"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "created"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#id"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id/scalar/id",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "id"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "id"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#topic"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic/scalar/topic",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "topic"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "topic"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#latest"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest/scalar/latest",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "latest"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "latest"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#last_read"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read/scalar/last_read",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "last_read"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "last_read"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#members"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members/scalar/members",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "members"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "members"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#creator"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator/scalar/creator",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "creator"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "creator"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_general"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general/scalar/is_general",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_general"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_general"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "ExtendingObj"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "channel"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#ok"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok/scalar/ok",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "ok"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ok"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "LibObjectWithExampleIncluded"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#examples": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "LLLLSSS"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#name": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "fun"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#created": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_6",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1360782804"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_6"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#creator": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_7",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "LLL"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_7"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_archived": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_8",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_8"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_general": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_9",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_9"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_member": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_10",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "true"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_10"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#members": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_11",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_11"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#topic": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_12",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_12"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#purpose": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_13",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_13"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#last_read": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_14",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1401383885.000061"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_14"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#latest": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_15",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_15"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#unread_count": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_16",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "0"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_16"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExampleIncluded/example/default-example/object_1/object_3/scalar_17",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "Nati"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_17"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#reference-id": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json#/external"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#location": [
+                  {
+                    "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#closed": [
+              {
+                "@value": false
+              }
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/channel",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#channel"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#NodeShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#closed": [
+                      {
+                        "@value": false
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#property": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#purpose"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose/scalar/purpose",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "purpose"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "purpose"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#owner"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner/scalar/owner",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "owner"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 1
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "owner"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_member"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member/scalar/is_member",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_member"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_member"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_archived"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived/scalar/is_archived",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_archived"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_archived"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name/scalar/name",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "name"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "name"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#unread_count"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count/scalar/unread_count",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://a.ml/vocabularies/shapes#number"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "unread_count"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "unread_count"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#created"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created/scalar/created",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "created"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "created"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#id"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id/scalar/id",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "id"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "id"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#topic"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic/scalar/topic",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "topic"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "topic"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#latest"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest/scalar/latest",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "latest"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "latest"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#last_read"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read/scalar/last_read",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "last_read"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "last_read"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#members"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members/scalar/members",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "members"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "members"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#creator"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator/scalar/creator",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "creator"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "creator"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#PropertyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#is_general"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#range": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general/scalar/is_general",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "is_general"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#minCount": [
+                          {
+                            "@value": 0
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_general"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "ExtendingObj"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "channel"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#ok"
+                  }
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok/scalar/ok",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "ok"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ok"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "LibObjectWithExamplesIncluded"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#examples": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "includedExample1"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "C024BE91L"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#name": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "fun"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#created": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_6",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1360782804"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_6"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#creator": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_7",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "U024BE7LH"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_7"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_archived": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_8",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_8"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_general": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_9",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_9"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_member": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_10",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "true"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_10"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#members": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_11",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_11"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#topic": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_12",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_12"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#purpose": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_13",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_13"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#last_read": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_14",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1401383885.000061"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_14"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#latest": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_15",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_15"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#unread_count": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_16",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "0"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_16"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample1/object_1/object_3/scalar_17",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "Caro"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_17"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#reference-id": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example.json#/external"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#location": [
+                  {
+                    "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example.json"
+                  }
+                ]
+              },
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Example",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "includedExample2"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#strict": [
+                  {
+                    "@value": true
+                  }
+                ],
+                "http://a.ml/vocabularies/document#structuredValue": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#ok": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/scalar_2",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_2"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#channel": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Object",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#id": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_4",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "LLLLSSS"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_4"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#name": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_5",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "fun"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_5"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#created": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_6",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1360782804"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_6"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#creator": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_7",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "LLL"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_7"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_archived": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_8",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_8"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_general": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_9",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "false"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_9"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#is_member": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_10",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "true"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_10"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#members": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_11",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_11"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#topic": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_12",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_12"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#purpose": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_13",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_13"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#last_read": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_14",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "1401383885.000061"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_14"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#latest": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_15",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": ""
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_15"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#unread_count": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_16",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "0"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_16"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/data#owner": [
+                          {
+                            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamplesIncluded/example/includedExample2/object_1/object_3/scalar_17",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "Nati"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_17"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "object_3"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_1"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document#reference-id": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json#/external"
+                  }
+                ],
+                "http://a.ml/vocabularies/document#location": [
+                  {
+                    "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#version": [
+          {
+            "@value": "2.0.0"
+          }
+        ],
+        "http://a.ml/vocabularies/document#references": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example.json",
+            "@type": [
+              "http://a.ml/vocabularies/document#ExternalFragment",
+              "http://a.ml/vocabularies/document#Fragment",
+              "http://a.ml/vocabularies/document#Unit"
+            ],
+            "http://a.ml/vocabularies/document#encodes": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example.json#/external",
+                "@type": [
+                  "http://a.ml/vocabularies/document#ExternalDomainElement",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/document#raw": [
+                  {
+                    "@value": "{\n  \"ok\" : true ,\n  \"channel\" : {\n    \"id\" : \"C024BE91L\" ,\n    \"name\" : \"fun\" ,\n    \"created\" : \"1360782804\" ,\n    \"creator\" : \"U024BE7LH\" ,\n    \"is_archived\" : false ,\n    \"is_general\" : false ,\n    \"is_member\" : true ,\n    \"members\" : \"\" ,\n    \"topic\" : \"\" ,\n    \"purpose\" : \"\" ,\n    \"last_read\" : \"1401383885.000061\" ,\n    \"latest\" : \"\" ,\n    \"unread_count\" : 0,\n    \"owner\" : \"Caro\" \n  }\n}"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#mediaType": [
+                  {
+                    "@value": "application/json"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#version": [
+              {
+                "@value": "2.0.0"
+              }
+            ],
+            "http://a.ml/vocabularies/document#root": [
+              {
+                "@value": false
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json",
+            "@type": [
+              "http://a.ml/vocabularies/document#ExternalFragment",
+              "http://a.ml/vocabularies/document#Fragment",
+              "http://a.ml/vocabularies/document#Unit"
+            ],
+            "http://a.ml/vocabularies/document#encodes": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json#/external",
+                "@type": [
+                  "http://a.ml/vocabularies/document#ExternalDomainElement",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/document#raw": [
+                  {
+                    "@value": "{\n  \"ok\" : true ,\n  \"channel\" : {\n    \"id\" : \"LLLLSSS\" ,\n    \"name\" : \"fun\" ,\n    \"created\" : \"1360782804\" ,\n    \"creator\" : \"LLL\" ,\n    \"is_archived\" : false ,\n    \"is_general\" : false ,\n    \"is_member\" : true ,\n    \"members\" : \"\" ,\n    \"topic\" : \"\" ,\n    \"purpose\" : \"\" ,\n    \"last_read\" : \"1401383885.000061\" ,\n    \"latest\" : \"\" ,\n    \"unread_count\" : 0,\n    \"owner\" : \"Nati\" \n  }\n}"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#mediaType": [
+                  {
+                    "@value": "application/json"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#version": [
+              {
+                "@value": "2.0.0"
+              }
+            ],
+            "http://a.ml/vocabularies/document#root": [
+              {
+                "@value": false
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#usage": [
+          {
+            "@value": "Defines types"
+          }
+        ],
+        "http://a.ml/vocabularies/document#root": [
+          {
+            "@value": false
+          }
+        ]
+      },
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/docs/documentationTitle.md",
+        "@type": [
+          "http://a.ml/vocabularies/document#ExternalFragment",
+          "http://a.ml/vocabularies/document#Fragment",
+          "http://a.ml/vocabularies/document#Unit"
+        ],
+        "http://a.ml/vocabularies/document#encodes": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/docs/documentationTitle.md#/external",
+            "@type": [
+              "http://a.ml/vocabularies/document#ExternalDomainElement",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "Another title"
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#version": [
+          {
+            "@value": "2.0.0"
+          }
+        ],
+        "http://a.ml/vocabularies/document#root": [
+          {
+            "@value": false
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#declares": [
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObj",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#closed": [
+          {
+            "@value": false
+          }
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObj/property/ok",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#ok"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObj/property/ok/scalar/ok",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ok"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "ok"
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObj/property/creationDate",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#creationDate"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObj/property/creationDate/scalar/creationDate",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#date"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "creationDate"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "creationDate"
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObj/property/owner",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#owner"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObj/property/owner/scalar/owner",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "owner"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "owner"
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": "MyObj"
+          }
+        ]
+      },
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#closed": [
+          {
+            "@value": false
+          }
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/channel",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#channel"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#closed": [
+                  {
+                    "@value": false
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#property": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#purpose"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose/scalar/purpose",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "purpose"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "purpose"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#owner"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner/scalar/owner",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "owner"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 1
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "owner"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#is_member"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member/scalar/is_member",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_member"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_member"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#is_archived"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived/scalar/is_archived",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_archived"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_archived"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name/scalar/name",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "name"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "name"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#unread_count"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count/scalar/unread_count",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://a.ml/vocabularies/shapes#number"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "unread_count"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "unread_count"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#created"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created/scalar/created",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "created"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "created"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#id"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id/scalar/id",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "id"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "id"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#topic"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic/scalar/topic",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "topic"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "topic"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#latest"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest/scalar/latest",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "latest"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "latest"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#last_read"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read/scalar/last_read",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "last_read"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "last_read"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#members"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members/scalar/members",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "members"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "members"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#creator"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator/scalar/creator",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "creator"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "creator"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#is_general"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general/scalar/is_general",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_general"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_general"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ExtendingObj"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "channel"
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#ok"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok/scalar/ok",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ok"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "ok"
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/property/creationDate",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#creationDate"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/property/creationDate/scalar/creationDate",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#date"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "creationDate"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "creationDate"
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": "MyObjExtendsLibObjWithEx"
+          }
+        ],
+        "http://a.ml/vocabularies/core#description": [
+          {
+            "@value": "My Own Channel Info"
+          }
+        ],
+        "http://a.ml/vocabularies/apiContract#examples": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex1",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "ex1"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex1/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex1/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "true"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#creationDate": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex1/object_1/scalar_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "2016-03-11"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#date"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex1/object_1/object_4",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex1/object_1/object_4/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "MyChannelInfoEx1"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex1/object_1/object_4/scalar_6",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "Tek"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_6"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_4"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "ok: true\ncreationDate: 2016-03-11\nchannel:\n  id: \"MyChannelInfoEx1\"\n  owner: \"Tek\""
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex2",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "ex2"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex2/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex2/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "true"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#creationDate": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex2/object_1/scalar_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "2016-04-11"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#date"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex2/object_1/object_4",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex2/object_1/object_4/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "MyChannelInfoEx2"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex2/object_1/object_4/scalar_6",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "Tek"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_6"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_4"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "ok: true\ncreationDate: 2016-04-11\nchannel:\n  id: \"MyChannelInfoEx2\"\n  owner: \"Tek\""
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex3",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "ex3"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex3/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex3/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "true"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#creationDate": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex3/object_1/scalar_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "2016-05-11"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#date"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex3/object_1/object_4",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex3/object_1/object_4/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "MyChannelInfoEx3"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/declarations/types/MyObjExtendsLibObjWithEx/example/ex3/object_1/object_4/scalar_6",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "Tek"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_6"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_4"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "ok: true\ncreationDate: 2016-05-11\nchannel:\n  id: \"MyChannelInfoEx3\"\n  owner: \"Tek\""
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#closed": [
+          {
+            "@value": false
+          }
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/channel",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#channel"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#closed": [
+                  {
+                    "@value": false
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#property": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#purpose"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose/scalar/purpose",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "purpose"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "purpose"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#owner"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner/scalar/owner",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "owner"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 1
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "owner"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#is_member"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member/scalar/is_member",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_member"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_member"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#is_archived"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived/scalar/is_archived",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_archived"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_archived"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name/scalar/name",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "name"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "name"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#unread_count"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count/scalar/unread_count",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://a.ml/vocabularies/shapes#number"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "unread_count"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "unread_count"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#created"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created/scalar/created",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "created"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "created"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#id"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id/scalar/id",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "id"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "id"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#topic"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic/scalar/topic",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "topic"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "topic"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#latest"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest/scalar/latest",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "latest"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "latest"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#last_read"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read/scalar/last_read",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "last_read"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "last_read"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#members"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members/scalar/members",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "members"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "members"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#creator"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator/scalar/creator",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "creator"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "creator"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#is_general"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general/scalar/is_general",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_general"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_general"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ExtendingObj"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "channel"
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#ok"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok/scalar/ok",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ok"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "ok"
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": "LibObjectWithExamples"
+          }
+        ],
+        "http://a.ml/vocabularies/apiContract#examples": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo1",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "ChannelInfo1"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo1/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo1/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "false"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo1/object_1/object_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo1/object_1/object_3/scalar_4",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "channel info 1"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_4"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "ok: false\nchannel:\n  owner: \"channel info 1\""
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "ChannelInfo2"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "true"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2/object_1/object_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2/object_1/object_3/scalar_4",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "pp"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_4"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/LibObjectWithExamples/example/ChannelInfo2/object_1/object_3/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "channel info 2"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "ok: true\nchannel:\n  owner: \"pp\"\n  id: \"channel info 2\""
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "example_0"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "true"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_4",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "LLLLSSS"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_4"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#name": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "fun"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#created": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_6",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "1360782804"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_6"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#creator": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_7",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "LLL"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_7"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_archived": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_8",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_8"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_general": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_9",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_9"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_member": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_10",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_10"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#members": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_11",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_11"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#topic": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_12",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_12"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#purpose": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_13",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_13"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#last_read": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_14",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "1401383885.000061"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_14"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#latest": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_15",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_15"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#unread_count": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_16",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "0"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_16"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_17",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "Nati"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_17"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#reference-id": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json#/external"
+              }
+            ],
+            "http://a.ml/vocabularies/document#location": [
+              {
+                "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example/source-map/tracked-element/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson/schema/example/default-example"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE1/get/200/application%2Fjson"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "example1"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "true"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/object_1/object_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_4",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "ex1"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_4"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "A"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "ok: true\nchannel:\n  id: \"ex1\"\n  owner: \"A\""
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1/source-map/tracked-element/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example1"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "example2"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "false"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/object_1/object_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_4",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "ex2"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_4"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "B"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "ok: false\nchannel:\n  id: \"ex2\"\n  owner: \"B\""
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2/source-map/tracked-element/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson/schema/example/example2"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE3/get/200/application%2Fjson"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#closed": [
+          {
+            "@value": false
+          }
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#ok"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/ok/scalar/ok",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ok"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "ok"
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/UsingObj/property/channel",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#channel"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#closed": [
+                  {
+                    "@value": false
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#property": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#purpose"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/purpose/scalar/purpose",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "purpose"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "purpose"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#owner"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/ExtendingObj/property/owner/scalar/owner",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "owner"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 1
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "owner"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#is_member"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_member/scalar/is_member",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_member"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_member"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#is_archived"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_archived/scalar/is_archived",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_archived"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_archived"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/name/scalar/name",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "name"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "name"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#unread_count"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/unread_count/scalar/unread_count",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://a.ml/vocabularies/shapes#number"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "unread_count"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "unread_count"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#created"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/created/scalar/created",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "created"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "created"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#id"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/id/scalar/id",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "id"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "id"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#topic"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/topic/scalar/topic",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "topic"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "topic"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#latest"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/latest/scalar/latest",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "latest"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "latest"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#last_read"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/last_read/scalar/last_read",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "last_read"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "last_read"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#members"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/members/scalar/members",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "members"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "members"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#creator"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/creator/scalar/creator",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "creator"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "creator"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#is_general"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/libraries/types.raml#/declarations/types/BaseObj/property/is_general/scalar/is_general",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "is_general"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#minCount": [
+                      {
+                        "@value": 0
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "is_general"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "ExtendingObj"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "channel"
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": "UsingObj"
+          }
+        ],
+        "http://a.ml/vocabularies/apiContract#examples": [
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "example_0"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "true"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_4",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "LLLLSSS"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_4"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#name": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "fun"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#created": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_6",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "1360782804"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_6"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#creator": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_7",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "LLL"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_7"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_archived": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_8",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_8"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_general": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_9",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_9"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_member": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_10",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_10"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#members": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_11",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_11"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#topic": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_12",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_12"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#purpose": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_13",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_13"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#last_read": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_14",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "1401383885.000061"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_14"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#latest": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_15",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_15"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#unread_count": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_16",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "0"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_16"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/object_1/object_3/scalar_17",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "Nati"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_17"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#reference-id": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json#/external"
+              }
+            ],
+            "http://a.ml/vocabularies/document#location": [
+              {
+                "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example/source-map/tracked-element/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson/schema/example/default-example"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE2/get/200/application%2Fjson"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "example1"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "true"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/object_1/object_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_4",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "ex1"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_4"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "A"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "ok: true\nchannel:\n  id: \"ex1\"\n  owner: \"A\""
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1/source-map/tracked-element/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example1"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "example2"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "false"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/object_1/object_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_4",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "ex2"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_4"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "B"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "ok: false\nchannel:\n  id: \"ex2\"\n  owner: \"B\""
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2/source-map/tracked-element/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson/schema/example/example2"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE4/get/200/application%2Fjson"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "example_1"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "true"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_4",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "C024BE91L"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_4"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#name": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "fun"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#created": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_6",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "1360782804"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_6"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#creator": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_7",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "U024BE7LH"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_7"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_archived": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_8",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_8"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_general": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_9",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_9"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_member": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_10",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_10"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#members": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_11",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_11"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#topic": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_12",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_12"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#purpose": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_13",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_13"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#last_read": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_14",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "1401383885.000061"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_14"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#latest": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_15",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_15"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#unread_count": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_16",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "0"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_16"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/object_1/object_3/scalar_17",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "Caro"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_17"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#reference-id": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example.json#/external"
+              }
+            ],
+            "http://a.ml/vocabularies/document#location": [
+              {
+                "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example.json"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1/source-map/tracked-element/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example1"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Example",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "example_2"
+              }
+            ],
+            "http://a.ml/vocabularies/document#strict": [
+              {
+                "@value": true
+              }
+            ],
+            "http://a.ml/vocabularies/document#structuredValue": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Object",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#ok": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/scalar_2",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Scalar",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#value": [
+                      {
+                        "@value": "true"
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "scalar_2"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/data#channel": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3",
+                    "@type": [
+                      "http://a.ml/vocabularies/data#Object",
+                      "http://a.ml/vocabularies/data#Node",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/data#id": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_4",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "LLLLSSS"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_4"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#name": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_5",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "fun"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_5"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#created": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_6",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "1360782804"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_6"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#creator": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_7",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "LLL"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_7"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_archived": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_8",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_8"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_general": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_9",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "false"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_9"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#is_member": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_10",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "true"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_10"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#members": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_11",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_11"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#topic": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_12",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_12"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#purpose": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_13",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_13"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#last_read": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_14",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "1401383885.000061"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_14"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#latest": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_15",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": ""
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_15"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#unread_count": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_16",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "0"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_16"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/data#owner": [
+                      {
+                        "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/object_1/object_3/scalar_17",
+                        "@type": [
+                          "http://a.ml/vocabularies/data#Scalar",
+                          "http://a.ml/vocabularies/data#Node",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/data#value": [
+                          {
+                            "@value": "Nati"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/core#name": [
+                          {
+                            "@value": "scalar_17"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/core#name": [
+                      {
+                        "@value": "object_3"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "object_1"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document#reference-id": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json#/external"
+              }
+            ],
+            "http://a.ml/vocabularies/document#location": [
+              {
+                "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/examples/usingObj-example2.json"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+                  {
+                    "@id": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2/source-map/tracked-element/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson/schema/example/example2"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "file:///Users/aloose/mulesoft/amf-runner-master/api/ConsoleTests_624604431218/ConsoleTest/api.raml#/web-api/end-points/%2FCASE5/get/200/application%2Fjson"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/demo/APIC-349-cache-resolution/api.raml
+++ b/demo/APIC-349-cache-resolution/api.raml
@@ -1,0 +1,141 @@
+#%RAML 1.0
+title: testExamples
+description: Testing examples display
+
+documentation:
+ - title: Test Console and Mocking Service
+   content: |
+     Welcome to the _Test API_ Documentation. The _Test API_
+     allows you to test console and mocking service features
+     [integration libraries](https://mulesoft.com)
+ - title: Legal
+   content: !include docs/api.md
+ - title: !include docs/documentationTitle.md
+   content: |
+     this is the content
+ - !include docs/DocumentationItem-1.raml
+uses:
+  myTypes: libraries/types.raml
+types:
+  MyObj :
+    type: object
+    properties:
+      ok: boolean
+      creationDate : date-only
+      owner: string
+  MyObjExtendsLibObjWithEx:
+    type: myTypes.LibObjectWithExample
+    description: My Own Channel Info
+    properties:
+      creationDate : date-only
+    examples:
+      ex1:
+        ok: true
+        creationDate: 2016-03-11
+        channel:
+          id: "MyChannelInfoEx1"
+          owner: "Tek"
+      ex2:
+        ok: true
+        creationDate: 2016-04-11
+        channel:
+          id: "MyChannelInfoEx2"
+          owner: "Tek"
+      ex3:
+        ok: true
+        creationDate: 2016-05-11
+        channel:
+          id: "MyChannelInfoEx3"
+          owner: "Tek"
+/CASE1:
+  get:
+    description: ExamplesInTypeAndExampleInResponseIncluded
+    queryParameters:
+      channel:
+        description: Channel to fetch history for.
+        required: true
+        example: C1234567890
+    responses:
+      200:
+        body:
+          application/json:
+            type: myTypes.LibObjectWithExamples
+            example: !include examples/usingObj-example2.json
+/CASE2:
+  get:
+    description: NoExamplesInTypeAndExampleInResponseIncluded
+    queryParameters:
+      channel:
+        description: Channel to fetch history for.
+        required: true
+        example: C1234567890
+    responses:
+      200:
+        body:
+          application/json:
+            type: myTypes.UsingObj
+            example: !include examples/usingObj-example2.json
+/CASE3:
+  get:
+    description: ExamplesInTypeAndExamplesInResponse
+    queryParameters:
+      channel:
+        description: Channel to fetch history for.
+        required: true
+        example: C1234567890
+    responses:
+      200:
+        body:
+          application/json:
+            type: myTypes.LibObjectWithExamples
+            examples:
+              example1:
+                ok: true
+                channel:
+                  id: "ex1"
+                  owner: "A"
+              example2:
+                ok: false
+                channel:
+                  id: "ex2"
+                  owner: "B"
+/CASE4:
+  get:
+    description: NoExamplesInTypeAndExamplesInResponseInline
+    queryParameters:
+      channel:
+        description: Channel to fetch history for.
+        required: true
+        example: C1234567890
+    responses:
+      200:
+        body:
+          application/json:
+            type: myTypes.UsingObj
+            examples:
+              example1:
+                ok: true
+                channel:
+                  id: "ex1"
+                  owner: "A"
+              example2:
+                ok: false
+                channel:
+                  id: "ex2"
+                  owner: "B"
+/CASE5:
+  get:
+    description: Testing No Examples In Type And Examples In Response using include. 
+    queryParameters:
+      channel:
+        description: Channel to fetch history for.
+        required: true
+        example: C1234567890
+    responses:
+      200:
+        body:
+          application/json:
+            type: myTypes.UsingObj
+            examples:
+              example1: !include examples/usingObj-example.json
+              example2: !include examples/usingObj-example2.json

--- a/demo/APIC-349-cache-resolution/docs/DocumentationItem-1.raml
+++ b/demo/APIC-349-cache-resolution/docs/DocumentationItem-1.raml
@@ -1,0 +1,3 @@
+#%RAML 1.0 DocumentationItem
+title: Fragment doc title
+content: Fragment doc content

--- a/demo/APIC-349-cache-resolution/docs/api.md
+++ b/demo/APIC-349-cache-resolution/docs/api.md
@@ -1,0 +1,1 @@
+The API gives you chance to test features referred to API Console and Mocking Service.

--- a/demo/APIC-349-cache-resolution/docs/documentationTitle.md
+++ b/demo/APIC-349-cache-resolution/docs/documentationTitle.md
@@ -1,0 +1,1 @@
+Another title

--- a/demo/APIC-349-cache-resolution/examples/usingObj-example.json
+++ b/demo/APIC-349-cache-resolution/examples/usingObj-example.json
@@ -1,0 +1,19 @@
+{
+  "ok" : true ,
+  "channel" : {
+    "id" : "C024BE91L" ,
+    "name" : "fun" ,
+    "created" : "1360782804" ,
+    "creator" : "U024BE7LH" ,
+    "is_archived" : false ,
+    "is_general" : false ,
+    "is_member" : true ,
+    "members" : "" ,
+    "topic" : "" ,
+    "purpose" : "" ,
+    "last_read" : "1401383885.000061" ,
+    "latest" : "" ,
+    "unread_count" : 0,
+    "owner" : "Caro" 
+  }
+}

--- a/demo/APIC-349-cache-resolution/examples/usingObj-example2.json
+++ b/demo/APIC-349-cache-resolution/examples/usingObj-example2.json
@@ -1,0 +1,19 @@
+{
+  "ok" : true ,
+  "channel" : {
+    "id" : "LLLLSSS" ,
+    "name" : "fun" ,
+    "created" : "1360782804" ,
+    "creator" : "LLL" ,
+    "is_archived" : false ,
+    "is_general" : false ,
+    "is_member" : true ,
+    "members" : "" ,
+    "topic" : "" ,
+    "purpose" : "" ,
+    "last_read" : "1401383885.000061" ,
+    "latest" : "" ,
+    "unread_count" : 0,
+    "owner" : "Nati" 
+  }
+}

--- a/demo/APIC-349-cache-resolution/libraries/schema.json
+++ b/demo/APIC-349-cache-resolution/libraries/schema.json
@@ -1,0 +1,21 @@
+{
+  "required" : true ,
+  "$schema" : "http://json-schema.org/draft-03/schema" ,
+  "type" : "object" ,
+  "properties" : {
+    "macro" : {
+      "type" : "object" ,
+      "required" : false ,
+      "properties" : {
+        "id" : {
+          "type" : "number" ,
+          "required" : false
+        } ,
+        "title" : {
+          "type" : "string" ,
+          "required" : false
+        }
+      }
+    }
+  }
+}

--- a/demo/APIC-349-cache-resolution/libraries/types.raml
+++ b/demo/APIC-349-cache-resolution/libraries/types.raml
@@ -1,0 +1,88 @@
+#%RAML 1.0 Library
+
+usage: Defines types
+types: 
+  BaseObj:
+    type: object
+    properties:
+      id:
+        type: string
+        required: false
+      name:
+        type: string
+        required: false
+      created:
+        type: string
+        required: false
+      creator:
+        type: string
+        required: false
+      is_archived:
+        type: boolean
+        required: false
+      is_general:
+        type: boolean
+        required: false
+      is_member:
+        type: boolean
+        required: false
+      members:
+        type: string
+        required: false
+      topic:
+        type: string
+        required: false
+      purpose:
+        type: string
+        required: false
+      last_read:
+        type: string
+        required: false
+      latest:
+        type: string
+        required: false
+      unread_count:
+        type: number
+        required: false
+  ExtendingObj:
+    type: BaseObj
+    properties: 
+      owner:
+        type : string
+        required: true
+  UsingObj:
+    type: object
+    properties:
+      ok:
+        type: boolean
+        required: false
+      channel:
+        type: ExtendingObj
+        required: true
+    
+  LibObjectWithExamples: 
+    type: UsingObj
+    examples:
+      ChannelInfo1: 
+        ok : false
+        channel: 
+          owner: "channel info 1"
+      ChannelInfo2:
+        ok: true
+        channel:
+          owner: "pp"
+          id: "channel info 2" 
+  LibObjectWithExample: 
+    type: UsingObj
+    example: 
+      ok : false
+      channel: 
+        owner: "single"
+  LibObjectWithExampleIncluded:
+    type: UsingObj
+    example: !include ../examples/usingObj-example2.json 
+  LibObjectWithExamplesIncluded:
+    type: UsingObj
+    examples: 
+      includedExample1: !include ../examples/usingObj-example.json 
+      includedExample2: !include ../examples/usingObj-example2.json 

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -968,7 +968,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
       return;
     }
     const rfIdKey = this._getAmfKey(this.ns.aml.vocabularies.document.referenceId);
-    const compareId = item['@id'].toLowerCase();
+    const compareId = item['@id'];
     const refNode = this._ensureArray(item[rfIdKey]);
     const refId = refNode ? refNode[0]['@id'].toLowerCase() : undefined;
     const idIndex = target._typeIds.indexOf(compareId);

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -970,7 +970,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     const rfIdKey = this._getAmfKey(this.ns.aml.vocabularies.document.referenceId);
     const compareId = item['@id'];
     const refNode = this._ensureArray(item[rfIdKey]);
-    const refId = refNode ? refNode[0]['@id'].toLowerCase() : undefined;
+    const refId = refNode ? refNode[0]['@id'] : undefined;
     const idIndex = target._typeIds.indexOf(compareId);
     const refIndex = refId ? target._typeIds.indexOf(refId) : -1;
     if (idIndex === -1 && refIndex === -1) {

--- a/test/amf-model.test.js
+++ b/test/amf-model.test.js
@@ -23,30 +23,30 @@ describe('AMF model test', () => {
           await nextFrame();
         });
 
-        it('Collects documentaion information', () => {
+        it('Collects documentation information', () => {
           const result = element._docs;
-          assert.isAbove(result.length, 0);
+          assert.equal(result.length, 2);
           assert.typeOf(result[0].id, 'string');
           assert.typeOf(result[0].label, 'string');
         });
 
         it('Collects types information', () => {
           const result = element._types;
-          assert.isAbove(result.length, 0);
+          assert.equal(result.length, 10);
           assert.typeOf(result[0].id, 'string');
           assert.typeOf(result[0].label, 'string');
         });
 
         it('Collects security information', () => {
           const result = element._security;
-          assert.isAbove(result.length, 0);
+          assert.equal(result.length, 2);
           assert.typeOf(result[0].id, 'string');
           assert.typeOf(result[0].label, 'string');
         });
 
         it('Collects endpoints information', () => {
           const result = element._endpoints;
-          assert.isAbove(result.length, 0);
+          assert.equal(result.length, 32);
           assert.typeOf(result[0].id, 'string');
           assert.typeOf(result[0].label, 'string');
           assert.typeOf(result[0].methods, 'array');
@@ -56,7 +56,7 @@ describe('AMF model test', () => {
         it('Collects methods information', () => {
           const result = element._endpoints;
           const methods = result[0].methods;
-          assert.isAbove(methods.length, 0);
+          assert.equal(methods.length, 2);
           assert.typeOf(methods[0].id, 'string');
           assert.typeOf(methods[0].label, 'string');
           assert.typeOf(methods[0].method, 'string');
@@ -92,6 +92,49 @@ describe('AMF model test', () => {
     });
   });
 
+  describe('AMF cache pipeline', () => {
+    describe('When model contains URI IDs', () => {
+      let element;
+
+      beforeEach(async () => {
+        const amf = await AmfLoader.load(false, 'APIC-349-cache-resolution');
+        element = await basicFixture();
+        element.amf = amf;
+        await nextFrame();
+      });
+
+      it('Collects documentation information', () => {
+        const result = element._docs;
+        assert.equal(result.length, 4);
+        assert.typeOf(result[0].id, 'string');
+        assert.typeOf(result[0].label, 'string');
+      });
+
+      it('Collects types information', () => {
+        const result = element._types;
+        assert.equal(result.length, 9);
+        assert.typeOf(result[0].id, 'string');
+        assert.typeOf(result[0].label, 'string');
+      });
+
+      it('Collects endpoints information', () => {
+        const result = element._endpoints;
+        assert.equal(result.length, 5);
+        assert.typeOf(result[0].id, 'string');
+        assert.typeOf(result[0].label, 'string');
+        assert.typeOf(result[0].methods, 'array');
+        assert.typeOf(result[0].renderPath, 'boolean');
+      });
+
+      it('Collects methods information', () => {
+        const result = element._endpoints;
+        const methods = result[0].methods;
+        assert.equal(methods.length, 1);
+        assert.typeOf(methods[0].id, 'string');
+        assert.typeOf(methods[0].method, 'string');
+      });
+    })
+  })
   describe('data-endpoint-* attributes', () => {
     [
       ['Regular model', false],


### PR DESCRIPTION
As AMF IDs may be in URI format, not only shortened format (amf://#1234), IDs should not be transformed to lower case when comparing against already resolved types in order to prevent duplicated types.