### PR TITLE
fix(rearrange-endpoints): rearrange before appendModelItem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ node_js: stable
 sudo: required
 addons:
   chrome: stable
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
 script:
   - npm run test
   - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:sl; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js: stable
 sudo: required
 addons:
+  chrome: stable
   apt:
     sources:
       - google-chrome

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-navigation",
   "description": "An element to display the response body",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "license": "Apache-2.0",
   "main": "api-navigation.js",
   "keywords": [

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -841,12 +841,12 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
       return;
     }
     const ekey = this._getAmfKey(this.ns.aml.vocabularies.apiContract.endpoint);
-    const endpoint = this._ensureArray(data[ekey]);
+    let endpoint = this._ensureArray(data[ekey]);
+    if (this.rearrangeEndpoints) {
+      endpoint = this._rearrangeEndpoints(endpoint);
+    }
     if (endpoint) {
       endpoint.forEach((item) => this._appendModelItem(item, target));
-    }
-    if (this.rearrangeEndpoints) {
-      target.endpoints = this._rearrangeEndpoints(target.endpoints);
     }
     const dkey = this._getAmfKey(this.ns.aml.vocabularies.core.documentation);
     const documentation = this._ensureArray(data[dkey]);
@@ -866,13 +866,15 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
       return [];
     }
 
-    function merge(left, right) {
+    const merge = (left, right) => {
       const resultArray = [];
       let leftIndex = 0;
       let rightIndex = 0;
 
       while (leftIndex < left.length && rightIndex < right.length) {
-        if (left[leftIndex].path < right[rightIndex].path) {
+        const leftPath = this._getValue(left[leftIndex], this.ns.raml.vocabularies.apiContract.path)
+        const rightPath = this._getValue(right[rightIndex], this.ns.raml.vocabularies.apiContract.path)
+        if (leftPath < rightPath) {
           resultArray.push(left[leftIndex]);
           leftIndex++;
         } else {
@@ -884,7 +886,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
       return resultArray.concat(left.slice(leftIndex)).concat(right.slice(rightIndex));
     }
 
-    function mergeSort(unsortedArray) {
+    const mergeSort = (unsortedArray) => {
       if (unsortedArray.length <= 1) {
         return unsortedArray;
       }
@@ -916,7 +918,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
    */
   _createListMap(endpoints) {
     const map = {};
-    const getPathInit = (endpoint) => endpoint.path.split('/')[1];
+    const getPathInit = (endpoint) => this._getValue(endpoint, this.ns.raml.vocabularies.apiContract.path).split('/')[1];
     endpoints.forEach((endpoint) => {
       const pathInit = getPathInit(endpoint);
       if (map[pathInit]) {

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -863,7 +863,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
    */
   _rearrangeEndpoints(endpoints) {
     if (!endpoints) {
-      return [];
+      return null;
     }
 
     const merge = (left, right) => {

--- a/test/api-navigation.test.js
+++ b/test/api-navigation.test.js
@@ -301,24 +301,26 @@ describe('<api-navigation>', () => {
     });
   });
 
-  describe('`Rearranging endpoints`', () => {
+  describe('Rearranging endpoint', () => {
     let element;
     let amf;
 
+    const pathKey = 'http://a.ml/vocabularies/apiContract#path'
+
     const dataSet = [
-      { path: '/transactions/:txId' },
-      { path: '/billing' },
-      { path: '/accounts/:accountId' },
-      { path: '/accounts' },
-      { path: '/transactions' },
+      { [pathKey]: '/transactions/:txId' },
+      { [pathKey]: '/billing' },
+      { [pathKey]: '/accounts/:accountId' },
+      { [pathKey]: '/accounts' },
+      { [pathKey]: '/transactions' },
     ];
 
     const expected = [
-      { path: '/transactions' },
-      { path: '/transactions/:txId' },
-      { path: '/billing' },
-      { path: '/accounts' },
-      { path: '/accounts/:accountId' }
+      { [pathKey]: '/transactions' },
+      { [pathKey]: '/transactions/:txId' },
+      { [pathKey]: '/billing' },
+      { [pathKey]: '/accounts' },
+      { [pathKey]: '/accounts/:accountId' }
     ];
 
     beforeEach(async () => {
@@ -334,7 +336,7 @@ describe('<api-navigation>', () => {
     it('should have endpoints rearranged', () => {
       element.amf = amf;
 
-      element._endpoints.forEach((endpoint, i) => assert.equal(endpoint.path, expected[i].path));
+      element._endpoints.forEach((endpoint, i) => assert.equal(endpoint.path, expected[i][pathKey]));
     });
   });
 


### PR DESCRIPTION
Change `_rearrangeEndpoints` to be called before appending items to model. Before this fix, when endpoints weren't in order, the full path was always displayed in each navigation item