### PR TITLE
fix: APIC-435 use title as label for documentation items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ coverage
 # AMF models
 /demo/*.json
 !demo/apis.json
+
+.idea

--- a/demo/APIC-435/APIC-435.yaml
+++ b/demo/APIC-435/APIC-435.yaml
@@ -1,0 +1,27 @@
+swagger: "2.0"
+info:
+  title: testExamples
+  description: Testing examples display
+  version: "1.0"
+externalDocs:
+  url: http://
+  description: |
+    Welcome to the _Test API_ Documentation. The _Test API_
+    allows you to test console and mocking service features
+    [integration libraries](https://mulesoft.com)
+  x-amf-title: Test Console and Mocking Service
+x-amf-userDocumentation:
+  -
+    url: http://
+    content: The API gives you chance to test features referred to API Console and Mocking Service.
+    title: Legal
+  -
+    url: http://
+    content: |
+      this is the content
+    title: Another title
+  -
+    url: http://
+    content: Fragment doc content
+    title: Fragment doc title
+paths: {}

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -16,5 +16,6 @@
   "oas-bearer/oas-bearer.yaml": "OAS 3.0",
   "oas-demo/oas-demo.yaml": "OAS 3.0",
   "APIC-349-cache-resolution/APIC-349-cache-resolution.raml": "RAML 1.0",
-  "ext-docs/ext-docs.yaml": "OAS 3.0"
+  "ext-docs/ext-docs.yaml": "OAS 3.0",
+  "APIC-435/APIC-435.yaml": "OAS 2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-navigation",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-navigation",
   "description": "An element to display the response body",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "license": "Apache-2.0",
   "main": "api-navigation.js",
   "keywords": [

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -937,7 +937,8 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     const urlNode = item[this._getAmfKey(core.url)];
     const url = urlNode ? (urlNode[0] || urlNode)['@id'] : undefined;
     const title = this._getValue(item, core.title);
-    const label = String(title);
+    const description = this._getValue(item, core.description);
+    const label = title ? String(title) : String(description);
     let isExternal = false;
     if (url) {
       isExternal = true;

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -348,8 +348,8 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     }
     this._selected = value;
     this.requestUpdate('selected', old);
-    this._selectedChangd(value);
-    this._selectionChnaged(value, this.selectedType);
+    this._selectedChanged(value);
+    this._selectionChanged(value, this.selectedType);
     this.dispatchEvent(
       new CustomEvent(`selected-changed`, {
         composed: true,
@@ -372,7 +372,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     }
     this._selectedType = value;
     this.requestUpdate('selectedType', old);
-    this._selectionChnaged(this.selected, value);
+    this._selectionChanged(this.selected, value);
     this.dispatchEvent(
       new CustomEvent(`selectedtype-changed`, {
         composed: true,
@@ -586,7 +586,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     this._endpoints = data.endpoints;
     this._closeCollapses();
     setTimeout(() => {
-      this._selectedChangd(this.selected);
+      this._selectedChanged(this.selected);
       this._resetTabindices();
     });
   }
@@ -936,15 +936,11 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     const id = item['@id'];
     const urlNode = item[this._getAmfKey(core.url)];
     const url = urlNode ? (urlNode[0] || urlNode)['@id'] : undefined;
+    const title = this._getValue(item, core.title);
+    const label = String(title);
     let isExternal = false;
-    let label;
     if (url) {
       isExternal = true;
-      const desc = this._getValue(item, core.description);
-      label = String(desc);
-    } else {
-      const title = this._getValue(item, core.title);
-      label = String(title);
     }
     const result = {
       id,
@@ -1186,7 +1182,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
    *
    * @param {string} current New selection
    */
-  _selectedChangd(current) {
+  _selectedChanged(current) {
     this._clearSelection();
     this._cleanPassiveSelection();
     if (current) {
@@ -1250,7 +1246,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
    * @param {string} selected Selected id
    * @param {string} selectedType Type of AMF shape
    */
-  _selectionChnaged(selected, selectedType) {
+  _selectionChanged(selected, selectedType) {
     if (!selectedType || this.__cancelNavigationEvent) {
       return;
     }

--- a/test/amf-model.test.js
+++ b/test/amf-model.test.js
@@ -223,6 +223,32 @@ describe('AMF model test', () => {
         });
       });
     });
+
+    [
+      ['Regular model', false],
+      ['Compact model', true],
+    ].forEach(item => {
+      describe(String(item[0]), () => {
+        let element;
+
+        beforeEach(async () => {
+          const amf = await AmfLoader.load(item[1], 'ext-docs');
+          element = await basicFixture();
+          element.amf = amf;
+          await nextFrame();
+        });
+
+        it('Collects documentation information', () => {
+          const result = element._docs;
+          assert.equal(result.length, 1);
+
+          assert.typeOf(result[0].id, 'string');
+          assert.equal(result[0].label, 'Docs');
+          assert.isTrue(result[0].isExternal);
+          assert.equal(result[0].url, 'https://example.com');
+        });
+      });
+    });
   });
 
   describe('_collectData()', () => {

--- a/test/amf-model.test.js
+++ b/test/amf-model.test.js
@@ -31,6 +31,7 @@ describe('AMF model test', () => {
           assert.equal(result.length, 2);
           assert.typeOf(result[0].id, 'string');
           assert.typeOf(result[0].label, 'string');
+          assert.equal(result[0].label, 'How to begin');
           assert.typeOf(result[0].isExternal, 'boolean');
           assert.isUndefined(result[0].url);
         });
@@ -178,6 +179,47 @@ describe('AMF model test', () => {
             assert.typeOf(nodes[i].dataset.endpointId, 'string');
             assert.isAbove(nodes[i].dataset.endpointId.length, 0);
           }
+        });
+      });
+    });
+
+    [
+      ['Regular model', false],
+      ['Compact model', true],
+    ].forEach(item => {
+      describe(String(item[0]), () => {
+        let element;
+
+        beforeEach(async () => {
+          const amf = await AmfLoader.load(item[1], 'APIC-435');
+          element = await basicFixture();
+          element.amf = amf;
+          await nextFrame();
+        });
+
+        it('Collects documentation information', () => {
+          const result = element._docs;
+          assert.equal(result.length, 4);
+
+          assert.typeOf(result[0].id, 'string');
+          assert.equal(result[0].label, 'Test Console and Mocking Service');
+          assert.isTrue(result[0].isExternal);
+          assert.equal(result[0].url, 'http://');
+
+          assert.typeOf(result[1].id, 'string');
+          assert.equal(result[1].label, 'Legal');
+          assert.isTrue(result[1].isExternal);
+          assert.equal(result[1].url, 'http://');
+
+          assert.typeOf(result[2].id, 'string');
+          assert.equal(result[2].label, 'Another title');
+          assert.isTrue(result[2].isExternal);
+          assert.equal(result[2].url, 'http://');
+
+          assert.typeOf(result[3].id, 'string');
+          assert.equal(result[3].label, 'Fragment doc title');
+          assert.isTrue(result[3].isExternal);
+          assert.equal(result[3].url, 'http://');
         });
       });
     });


### PR DESCRIPTION
bug: Listing descriptions of documentation items when it should list their titles
fix: Use title as label for documentation items