### PR TITLE
Fix unordered endpoint path names

### DIFF
--- a/demo/apis.json
+++ b/demo/apis.json
@@ -1,6 +1,7 @@
 {
   "demo-api/demo-api.raml": "RAML 1.0",
   "types-list/types-list.raml": "RAML 1.0",
+  "unordered-endpoints/unordered-endpoints.raml": "RAML 1.0",
   "exchange-experience-api/exchange-experience-api.raml": "RAML 0.8",
   "oauth1-fragment/oauth1-fragment.raml": "RAML 1.0",
   "oauth2-fragment/oauth2-fragment.raml": "RAML 1.0",

--- a/demo/lib/common.js
+++ b/demo/lib/common.js
@@ -94,6 +94,7 @@ export class NavDemoPage extends DemoPage {
       ['ext-docs', 'External docs'],
       ['APIC-449', 'APIC-449'],
       ['async-api', 'AsyncAPI'],
+      ['unordered-endpoints', 'vunordered-endpoints'],
     ].map(
       ([file, label]) => html`
         <anypoint-item data-src="${file}-compact.json"

--- a/demo/lib/common.js
+++ b/demo/lib/common.js
@@ -94,7 +94,7 @@ export class NavDemoPage extends DemoPage {
       ['ext-docs', 'External docs'],
       ['APIC-449', 'APIC-449'],
       ['async-api', 'AsyncAPI'],
-      ['unordered-endpoints', 'vunordered-endpoints'],
+      ['unordered-endpoints', 'Unordered endpoints API'],
     ].map(
       ([file, label]) => html`
         <anypoint-item data-src="${file}-compact.json"

--- a/demo/unordered-endpoints/unordered-endpoints.raml
+++ b/demo/unordered-endpoints/unordered-endpoints.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+title: Out of order endpoints
+/foo:
+  get:
+    displayName: Get foo
+/bar:
+  get:
+    displayName: Get bar
+/foo/bar:
+  get:
+    displayName: Get foo bar

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-navigation",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-navigation",
   "description": "An element to display the response body",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "Apache-2.0",
   "main": "api-navigation.js",
   "keywords": [

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -989,7 +989,11 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
       if (lowerParts.length) {
         for (let i = lowerParts.length - 1; i >= 0; i--) {
           const currentPath = `/${lowerParts.slice(0, i + 1).join('/')}`;
-          if (target._basePaths.indexOf(currentPath) !== -1) {
+          if (
+            target._basePaths[target._basePaths.length - 2].startsWith(
+              currentPath
+            )
+          ) {
             indent++;
           }
         }

--- a/test/api-navigation.test.js
+++ b/test/api-navigation.test.js
@@ -10,6 +10,7 @@ import { computePathName, computeRenderPath } from '../src/ApiNavigation.js';
 
 describe('<api-navigation>', () => {
   const asyncApi = 'async-api';
+  const unorderedEndpoints = 'unordered-endpoints';
 
   async function basicFixture() {
     return fixture(`<api-navigation></api-navigation>`);
@@ -958,6 +959,27 @@ describe('<api-navigation>', () => {
           element.shadowRoot.querySelector('.endpoints div.title-h3')
             .textContent,
           'Channels'
+        );
+      });
+    });
+
+    describe('Unordered endpoints', () => {
+      let amf;
+      let element;
+
+      beforeEach(async () => {
+        amf = await AmfLoader.load(item[1], unorderedEndpoints);
+        element = await basicFixture();
+        element.amf = amf;
+        await nextFrame();
+      });
+
+      it('should render full path of third endpoint', () => {
+        assert.equal(
+          element.shadowRoot.querySelectorAll(
+            '.list-item.endpoint .endpoint-name'
+          )[2].innerText,
+          '/foo/bar'
         );
       });
     });


### PR DESCRIPTION
When shortening endpoint name paths, we're taking into account that ANY previous endpoint's path.

This change only takes into account the immediately previous endpoint, and applies indentation as necessary.