### PR TITLE
Fix/nested endpoints bug (Part II)

### DIFF
--- a/demo/APIC-554-ii/APIC-554-ii.raml
+++ b/demo/APIC-554-ii/APIC-554-ii.raml
@@ -1,0 +1,5 @@
+#%RAML 1.0
+title: api
+
+/customers/{customer}/chromeos/deviceId:
+/customer/{customer}/chromeos/deviceId:

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -22,5 +22,6 @@
   "APIC-449/APIC-449.yaml": "OAS 3.0",
   "async-api/async-api.yaml": "ASYNC 2.0",
   "APIC-550/APIC-550.raml": "RAML 1.0",
-  "APIC-554/APIC-554.raml": "RAML 1.0"
+  "APIC-554/APIC-554.raml": "RAML 1.0",
+  "APIC-554-ii/APIC-554-ii.raml": "RAML 1.0"
 }

--- a/demo/lib/common.js
+++ b/demo/lib/common.js
@@ -96,6 +96,7 @@ export class NavDemoPage extends DemoPage {
       ['async-api', 'AsyncAPI'],
       ['unordered-endpoints', 'Unordered endpoints API'],
       ['APIC-554', 'APIC-554'],
+      ['APIC-554-ii', 'APIC-554-ii'],
     ].map(
       ([file, label]) => html`
         <anypoint-item data-src="${file}-compact.json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-navigation",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-navigation",
   "description": "An element to display the response body",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "license": "Apache-2.0",
   "main": "api-navigation.js",
   "keywords": [

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -993,7 +993,8 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
             target._basePaths[target._basePaths.length - 2];
           if (
             previousBasePathItem &&
-            previousBasePathItem.startsWith(currentPath)
+            (previousBasePathItem === currentPath ||
+              previousBasePathItem.startsWith(`${currentPath}/`))
           ) {
             indent++;
           }

--- a/test/api-navigation.test.js
+++ b/test/api-navigation.test.js
@@ -1020,6 +1020,30 @@ describe('<api-navigation>', () => {
         );
       });
     });
+
+    describe('APIC-554-ii', () => {
+      let amf;
+      let element;
+
+      before(async () => {
+        amf = await AmfLoader.load(item[1], 'APIC-554-ii');
+      });
+
+      beforeEach(async () => {
+        element = await modelFixture(amf);
+      });
+
+      it('should compute endpoint names correctly', () => {
+        const labels = [
+          '/customers/{customer}/chromeos/deviceId',
+          '/customer/{customer}/chromeos/deviceId',
+        ];
+        assert.deepEqual(
+          element._endpoints.map(e => e.label),
+          labels
+        );
+      });
+    });
   });
 
   describe('a11y', () => {


### PR DESCRIPTION
When path names are very similar, they might have an empty label