### PR TITLE
Sort endpoints & render full paths

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -6,13 +6,13 @@ export class DemoPage extends NavDemoPage {
   constructor() {
     super();
     this.initObservableProperties([
-      'summary', 'noink', 'allowPaths', 'rearrangeEndpoints', 'operationsOpened', 'noOverview'
+      'summary', 'noink', 'allowPaths', 'sortEndpoints', 'operationsOpened', 'noOverview'
     ]);
     this.compatibility = false;
     this.summary = true;
     this.noink = false;
     this.allowPaths = false;
-    this.rearrangeEndpoints = false;
+    this.sortEndpoints = false;
     this.operationsOpened = true;
     this.noOverview = false;
   }
@@ -26,7 +26,7 @@ export class DemoPage extends NavDemoPage {
       summary,
       noink,
       allowPaths,
-      rearrangeEndpoints,
+      sortEndpoints,
       operationsOpened,
       noOverview,
     } = this;
@@ -50,7 +50,7 @@ export class DemoPage extends NavDemoPage {
           ?summary="${summary}"
           ?noink="${noink}"
           ?allowPaths="${allowPaths}"
-          ?rearrangeEndpoints="${rearrangeEndpoints}"
+          ?sortEndpoints="${sortEndpoints}"
           ?compatibility="${compatibility}"
           ?noOverview="${noOverview}"
           slot="content"
@@ -87,10 +87,10 @@ export class DemoPage extends NavDemoPage {
         <anypoint-checkbox
           aria-describedby="mainOptionsLabel"
           slot="options"
-          name="rearrangeEndpoints"
+          name="sortEndpoints"
           @change="${this._toggleMainOption}"
         >
-          Rearrange endpoints
+          Sort endpoints
         </anypoint-checkbox>
         <anypoint-checkbox
           aria-describedby="mainOptionsLabel"

--- a/demo/index.js
+++ b/demo/index.js
@@ -6,13 +6,13 @@ export class DemoPage extends NavDemoPage {
   constructor() {
     super();
     this.initObservableProperties([
-      'summary', 'noink', 'allowPaths', 'sortEndpoints', 'operationsOpened', 'noOverview', 'renderFullPaths'
+      'summary', 'noink', 'allowPaths', 'rearrangeEndpoints', 'operationsOpened', 'noOverview', 'renderFullPaths'
     ]);
     this.compatibility = false;
     this.summary = true;
     this.noink = false;
     this.allowPaths = false;
-    this.sortEndpoints = false;
+    this.rearrangeEndpoints = false;
     this.operationsOpened = true;
     this.noOverview = false;
     this.renderFullPaths = false;
@@ -27,7 +27,7 @@ export class DemoPage extends NavDemoPage {
       summary,
       noink,
       allowPaths,
-      sortEndpoints,
+      rearrangeEndpoints,
       operationsOpened,
       noOverview,
       renderFullPaths,
@@ -52,7 +52,7 @@ export class DemoPage extends NavDemoPage {
           ?summary="${summary}"
           ?noink="${noink}"
           ?allowPaths="${allowPaths}"
-          ?sortEndpoints="${sortEndpoints}"
+          ?rearrangeEndpoints="${rearrangeEndpoints}"
           ?compatibility="${compatibility}"
           ?noOverview="${noOverview}"
           slot="content"
@@ -90,7 +90,7 @@ export class DemoPage extends NavDemoPage {
         <anypoint-checkbox
           aria-describedby="mainOptionsLabel"
           slot="options"
-          name="sortEndpoints"
+          name="rearrangeEndpoints"
           @change="${this._toggleMainOption}"
         >
           Sort endpoints

--- a/demo/index.js
+++ b/demo/index.js
@@ -6,7 +6,7 @@ export class DemoPage extends NavDemoPage {
   constructor() {
     super();
     this.initObservableProperties([
-      'summary', 'noink', 'allowPaths', 'sortEndpoints', 'operationsOpened', 'noOverview'
+      'summary', 'noink', 'allowPaths', 'sortEndpoints', 'operationsOpened', 'noOverview', 'renderFullPaths'
     ]);
     this.compatibility = false;
     this.summary = true;
@@ -15,6 +15,7 @@ export class DemoPage extends NavDemoPage {
     this.sortEndpoints = false;
     this.operationsOpened = true;
     this.noOverview = false;
+    this.renderFullPaths = false;
   }
 
   _demoTemplate() {
@@ -29,6 +30,7 @@ export class DemoPage extends NavDemoPage {
       sortEndpoints,
       operationsOpened,
       noOverview,
+      renderFullPaths,
     } = this;
     return html `
     <section class="documentation-section">
@@ -55,6 +57,7 @@ export class DemoPage extends NavDemoPage {
           ?noOverview="${noOverview}"
           slot="content"
           ?operationsOpened="${operationsOpened}"
+          ?renderFullPaths="${renderFullPaths}"
         ></api-navigation>
 
         <label slot="options" id="mainOptionsLabel">Options</label>
@@ -107,6 +110,15 @@ export class DemoPage extends NavDemoPage {
           @change="${this._toggleMainOption}"
         >
           No overview
+        </anypoint-checkbox>
+        </anypoint-checkbox>
+        <anypoint-checkbox
+          aria-describedby="mainOptionsLabel"
+          slot="options"
+          name="renderFullPaths"
+          @change="${this._toggleMainOption}"
+        >
+          Render full paths
         </anypoint-checkbox>
       </arc-interactive-demo>
     </section>`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-navigation",
-  "version": "4.2.8",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,115 +29,113 @@
       }
     },
     "@advanced-rest-client/arc-fit-mixin": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-fit-mixin/-/arc-fit-mixin-1.2.1.tgz",
-      "integrity": "sha512-r7QWIOKRRY4+Cn7/cILJKMf63V5nlb/Ej6B58DftLXOMJ5hqKPKdJWuXB+DRHAwAEfF+FhCmY5HfibSmCskj+Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-fit-mixin/-/arc-fit-mixin-1.2.2.tgz",
+      "integrity": "sha512-fakoD1QuLM3QswgnlZXEWJ3SAHEFziF8BnNLWGN4BpBF1vu6y9nJDBEC+SpOaz0yvMa07BCRD7InJ+2ZEX41vA==",
       "dev": true,
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0"
       }
     },
     "@advanced-rest-client/arc-icons": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-icons/-/arc-icons-3.3.1.tgz",
-      "integrity": "sha512-EJC+DNnKyUEuPIzZeKsEDGd40XdMc9dN/wPb8MupQAuoy21Q7oZj8adUnJ4egpmkA0xI8mk5UAyQnO3N4ethKw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-icons/-/arc-icons-3.3.3.tgz",
+      "integrity": "sha512-bmiVGfNo463p2cb1Mvy2KF5QvUV/dL0JG+H6AivYJdNNFTeEAt5a2s+K/QkWHCLPAK/gKdgyrUxBZtxRIguJ1A==",
       "requires": {
-        "@polymer/iron-icon": "^3.0.1",
-        "@polymer/iron-iconset-svg": "^3.0.1",
         "lit-element": "^2.4.0",
         "lit-html": "^1.3.0"
       }
     },
     "@advanced-rest-client/arc-overlay-mixin": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-overlay-mixin/-/arc-overlay-mixin-1.1.7.tgz",
-      "integrity": "sha512-Q3JHK2F0S5lFv3Xrp9DYuswzXC0O421i3PkGELfaznvRnuOD/0r8irlgShWXWltQbl9A79uKG11mnfU37aRXUA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-overlay-mixin/-/arc-overlay-mixin-1.2.0.tgz",
+      "integrity": "sha512-NYUspnkQLGudh9NM8vNzORjMYjv2PvL4NiS5Jj4VLvF234Z29iKOpRh+m3+ESmouEs6nZyvh4T/DNGrsD4c+fA==",
       "dev": true,
       "requires": {
-        "@advanced-rest-client/arc-fit-mixin": "^1.2.1",
-        "@advanced-rest-client/arc-resizable-mixin": "^1.1.2",
+        "@advanced-rest-client/arc-fit-mixin": "^1.2.2",
+        "@advanced-rest-client/arc-resizable-mixin": "^1.2.0",
         "@open-wc/dedupe-mixin": "^1.3.0",
         "lit-element": "^2.4.0",
         "lit-html": "^1.3.0"
       }
     },
     "@advanced-rest-client/arc-resizable-mixin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-resizable-mixin/-/arc-resizable-mixin-1.2.0.tgz",
-      "integrity": "sha512-hc8XjY6CfQDANuf0TfsfE6EWJwlXBZTtmv2h4luLZgHz55XPlWO7w2XI/YAZX6xQpcsR3cGv0eDnj9CkOaCcCQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-resizable-mixin/-/arc-resizable-mixin-1.2.2.tgz",
+      "integrity": "sha512-Z7+dfxTP7nqPgfxVgYduUVVg2ApTw767zYL1SRpUZx/v2AMZsSXB1bvWqVCatAzpQPNcZwWbCTChtwL5Nh7omQ==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0"
       }
     },
     "@anypoint-web-components/anypoint-button": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-button/-/anypoint-button-1.2.0.tgz",
-      "integrity": "sha512-z3og4oxSlwo37ISbg4S32/NeOqtJcsEfAk4CQ1c4tJM/TsI+lTFLZHwNELeunRg8yoGGnjhrnrxTbin+YKfYBQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-button/-/anypoint-button-1.2.1.tgz",
+      "integrity": "sha512-YQshPA8iNgUr2yBcVOAi4P+yFrid6dSFU+5Uu3PfY2BupnwKCMQqJ3wkcLizQXpMwuaJMXZr/1mXjIFKtx0F2w==",
       "requires": {
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
         "@polymer/paper-ripple": "^3.0.2",
-        "lit-element": "^2.4.0"
+        "lit-element": "^2.5.1"
       }
     },
     "@anypoint-web-components/anypoint-checkbox": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-checkbox/-/anypoint-checkbox-1.1.4.tgz",
-      "integrity": "sha512-ZYtA74X2L1vsvAF48U+6ItCfTnymtDZYEPNc3w4zdYqcQD/G05boKtS1HGD6pGuY2K+1eIhXAHDvYyyEheTuvg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-checkbox/-/anypoint-checkbox-1.2.1.tgz",
+      "integrity": "sha512-HoLMfQDBUnEpEp1Qni0lqpcqwSgbZDgpzUgzG5Nrly3T/z9F+ZCm8DdD2cBEW0sAO08U5/SgvItcP4qpsWF6Mw==",
       "dev": true,
       "requires": {
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
-        "@anypoint-web-components/anypoint-form-mixins": "^1.2.2",
-        "lit-element": "^2.4.0"
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
+        "@anypoint-web-components/anypoint-form-mixins": "^1.3.0",
+        "lit-element": "^2.5.1"
       }
     },
     "@anypoint-web-components/anypoint-collapse": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-collapse/-/anypoint-collapse-0.1.0.tgz",
-      "integrity": "sha512-EVl5sVD3ErRN2MNOcWNck/huuRW5/RJVGuK/YK+dWwg602OQ9L2RbLLJrS0GQ7hh8al/1DmhdmGauK73QkTM1A==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-collapse/-/anypoint-collapse-0.1.2.tgz",
+      "integrity": "sha512-+arHE/rxvtXLs01R9XNrLPWEO5n7f8KcmvKhiq7Er5pqt49O6VbZIcdqEHiuhRigjsObE3/x0SP4OMuDMrO9fw==",
       "requires": {
-        "@advanced-rest-client/arc-resizable-mixin": "^1.1.0",
-        "lit-element": "^2.2.1",
-        "lit-html": "^1.1.2"
+        "@advanced-rest-client/arc-resizable-mixin": "^1.2.0",
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@anypoint-web-components/anypoint-control-mixins": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-control-mixins/-/anypoint-control-mixins-1.1.3.tgz",
-      "integrity": "sha512-LRhwEav2ZpDBRKiGo3Upu4B0ur/j8+2JxeqHGwxcXc8ORuiJLVxcorURuKhLyvEjk5fP5pI0S0KGIUj66N1KQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-control-mixins/-/anypoint-control-mixins-1.2.0.tgz",
+      "integrity": "sha512-EMseskbHaRBJpyV60m6tWCtr1MGMZV/Hc6yD5XO1fH4WCg8kihgqXWeR22Y5qOv7YaALwWwBrG2cDCG8TNyxHw==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0"
       }
     },
     "@anypoint-web-components/anypoint-dropdown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-dropdown/-/anypoint-dropdown-1.1.4.tgz",
-      "integrity": "sha512-t84wYqpeljd2+41Ci/ME82o1R2qL1gn3mLTmHx3J+oS8ou0FOGhSHKKuxchF0Y87ydE1fGmWdE6Im4FIwLUCKQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-dropdown/-/anypoint-dropdown-1.1.6.tgz",
+      "integrity": "sha512-pYbyAud5HnkeSiR+jy4pYbf0O+dBySApITzvqw3aAL1P+OiiSuOlHg+ghYL4q4HQCWF5rRhu+Hiv8CrVcS/bkQ==",
       "dev": true,
       "requires": {
-        "@advanced-rest-client/arc-overlay-mixin": "^1.1.7",
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "@advanced-rest-client/arc-overlay-mixin": "^1.2.0",
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@anypoint-web-components/anypoint-dropdown-menu": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-dropdown-menu/-/anypoint-dropdown-menu-0.1.20.tgz",
-      "integrity": "sha512-iqV6KkorsP7vUtNX/zKv3Pxy/oktXbijdjCDjHwzxJ/jzuokJc+Y4VhnLdQ3B0dNUn+D2Mg3lhppy1FwLl6oZg==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-dropdown-menu/-/anypoint-dropdown-menu-0.1.21.tgz",
+      "integrity": "sha512-AQJHAFfWAOwSB5iQHjume65udiDva31NSGLWRnCov06VHlph+iO2ztp1iuMZLrJQLFiIYUc+uYFta6gmG8jtVQ==",
       "dev": true,
       "requires": {
-        "@anypoint-web-components/anypoint-button": "^1.1.1",
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
-        "@anypoint-web-components/anypoint-dropdown": "^1.1.4",
+        "@anypoint-web-components/anypoint-button": "^1.2.0",
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
+        "@anypoint-web-components/anypoint-dropdown": "^1.1.5",
         "@anypoint-web-components/validatable-mixin": "^1.1.3",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@anypoint-web-components/anypoint-form-mixins": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-form-mixins/-/anypoint-form-mixins-1.2.2.tgz",
-      "integrity": "sha512-Z9aC5WZOr58GnabwPhVq8OpZ6Yk6RU/HGX/uC9mP2h5cohTqCCwZBgyDmRE5YzjBidaWR+9mCUPKJsxl9Z9AEA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-form-mixins/-/anypoint-form-mixins-1.3.0.tgz",
+      "integrity": "sha512-gm+474ZGNQSJcPcGKT1Ixmp3hDtFpfBDn8HawwJV8MxXkTIYdgfz3B6WpKu4VvYLJIlk9GJb4MbbNMK+hJ6XMA==",
       "dev": true,
       "requires": {
         "@anypoint-web-components/validatable-mixin": "^1.1.3",
@@ -145,32 +143,32 @@
       }
     },
     "@anypoint-web-components/anypoint-item": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-item/-/anypoint-item-1.1.0.tgz",
-      "integrity": "sha512-a4Lz1p5vpdgxeQ4sTAr23kiV9cvKAQ6aVGXRbrEOVYpXKkBJVlkWPvIJ44i14e6APW9F4kY0nczQayAn83QDfg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-item/-/anypoint-item-1.1.2.tgz",
+      "integrity": "sha512-AD702ZKg6AW+0wUlE/UHMLcVUGlwgDXRjhmtMSH5vp1gGBbg4OzhiUN8/kwLiWIC5O4yyikUBpFmuD09VGQc1A==",
       "dev": true,
       "requires": {
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
         "@anypoint-web-components/anypoint-styles": "^1.0.1",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@anypoint-web-components/anypoint-listbox": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-listbox/-/anypoint-listbox-1.1.6.tgz",
-      "integrity": "sha512-YkQuORirn6k+erAeB1H1OZgFqc7gOPcGaJoH+TuXW8Sb5gdburU8UtdTnO9CvZ/a+pCcIE35EgrdcInBglXGiQ==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-listbox/-/anypoint-listbox-1.1.7.tgz",
+      "integrity": "sha512-F4VueUMEdH8unfJ5Wyqv4QO8Cfl/F1lkq0o7vrKPafYyK455ArIx1CCsgUUUhXAG8+T4WZie5xfnqVRr+uYWpA==",
       "dev": true,
       "requires": {
         "@anypoint-web-components/anypoint-menu-mixin": "^1.1.7",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@anypoint-web-components/anypoint-menu-button": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-menu-button/-/anypoint-menu-button-0.1.4.tgz",
-      "integrity": "sha512-wPGgvTYZtegArAqsMkA+M7b9UodW2bFPkG/87s/FEj9MXUrLAarevqNq/oHeKBCq598Sl5P2o2XG5fZm5AX8Qg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-menu-button/-/anypoint-menu-button-0.1.5.tgz",
+      "integrity": "sha512-sZKu3qLbRrGX9RMxKayS9jS41eTmaktYQXsrR9v32MbenMyI+FJ0IIZEidxSq5WFbYoLYih/iCaK57sFMepr9g==",
       "dev": true,
       "requires": {
         "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
@@ -213,30 +211,29 @@
       }
     },
     "@anypoint-web-components/anypoint-switch": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-switch/-/anypoint-switch-0.1.5.tgz",
-      "integrity": "sha512-1suznLBwEEZe0x3qaxmxLTwSkYnmI1uMLjRUV3jcAUBPT5xhuBwA3dCcKriT5qhVyUiwkDqVgl0jDZcd6oLmiA==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-switch/-/anypoint-switch-0.1.10.tgz",
+      "integrity": "sha512-EXE+6nF52TBOcx8sXDLmVmR9jliZzsG3zsPm6BFbWLofO0E6ZqPy7y6+yhyaIMCyl8M5GZWE9n+w7oyDQvELxQ==",
       "dev": true,
       "requires": {
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
-        "@anypoint-web-components/anypoint-form-mixins": "^1.2.2",
-        "lit-element": "^2.4.0"
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
+        "@anypoint-web-components/anypoint-form-mixins": "^1.3.0",
+        "lit-element": "^2.5.1"
       }
     },
     "@anypoint-web-components/anypoint-tabs": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-tabs/-/anypoint-tabs-0.1.12.tgz",
-      "integrity": "sha512-t3Qe9JPRJCof5LMMVDcOqltDnGvpigUboxASVrovuf0iPeDYgPWjJ59pNgeLFnT20LGsZVgEAGWBnOuuK5XGuw==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-tabs/-/anypoint-tabs-0.1.17.tgz",
+      "integrity": "sha512-hBAoU0hjp8GusWKK/F2Urt1OvCn7KgEfOdYUahjb6u242lvUkOaMfP9kD1Qp92fRa9mA/wjL7tsNtnWeZ7hTQQ==",
       "dev": true,
       "requires": {
-        "@advanced-rest-client/arc-resizable-mixin": "^1.1.1",
-        "@anypoint-web-components/anypoint-button": "^1.1.1",
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.2",
-        "@anypoint-web-components/anypoint-menu-mixin": "^1.1.7",
-        "@polymer/iron-icon": "^3.0.1",
+        "@advanced-rest-client/arc-resizable-mixin": "^1.2.1",
+        "@anypoint-web-components/anypoint-button": "^1.2.0",
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
+        "@anypoint-web-components/anypoint-menu-mixin": "^1.1.8",
         "@polymer/paper-ripple": "^3.0.2",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@anypoint-web-components/validatable-mixin": {
@@ -259,24 +256,27 @@
       }
     },
     "@api-components/amf-helper-mixin": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.3.4.tgz",
-      "integrity": "sha512-YJg3gmckxI07Rw8B/5DCZMHoEC/Exl+FF1wDThfcN35UfE7yBrcAEQ4zbGcMHdloZQDPpg7B/KAV5g9pzdD/KQ=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.4.0.tgz",
+      "integrity": "sha512-XHFM7oKrDjF4xwikhl2MPE0qo8P2SC9/ByfUz52wPAKGvM2gdVwJ/VrkpK2iQ0HLojwRaqM4ejy+0AMeeRJOXA==",
+      "requires": {
+        "amf-json-ld-lib": "0.0.13"
+      }
     },
     "@api-components/api-model-generator": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@api-components/api-model-generator/-/api-model-generator-0.2.9.tgz",
-      "integrity": "sha512-1SGQVuJZDqJwgQeaNY+kf1rW/xov7V9YWbhOEH/F0rk2jQgZXV9C4sXyxg5LBsT4swIsD06R1qoM83YSbY052Q==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@api-components/api-model-generator/-/api-model-generator-0.2.13.tgz",
+      "integrity": "sha512-G92MvXqWBVh7KNbYGto7vg5grMbUGBYKyZw8X2WSp2b4VwholspY9zMzqZA+Zpwrt9lK8RvPLkbaLWi4micyvQ==",
       "dev": true,
       "requires": {
-        "amf-client-js": "^4.4.0",
-        "fs-extra": "^8.1.0"
+        "amf-client-js": "^4.7.4",
+        "fs-extra": "^10.0.0"
       }
     },
     "@api-components/api-navigation": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@api-components/api-navigation/-/api-navigation-4.2.7.tgz",
-      "integrity": "sha512-FGmA61Ma4vgPbbUlEFv/6dBnWDwzcUbZ7dzsfGd62UTv9Df4SSlUpwnzLcQHvODi/lnWX8rhMT1GsMO1WbZzLA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@api-components/api-navigation/-/api-navigation-4.2.8.tgz",
+      "integrity": "sha512-biv4bYyiLW0VSNVkeW73ZpZ1wuT9yoCEIQ8jFIOxzZ0syQc587gSfim+4zdj+FAFAGooU3Z3nN40KVXJpzubKg==",
       "dev": true,
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
@@ -290,9 +290,9 @@
       }
     },
     "@api-components/http-method-label": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@api-components/http-method-label/-/http-method-label-3.1.3.tgz",
-      "integrity": "sha512-Pz1vpq26kntclfxj0Ym5e/6h4DN2CZWFR4DHJidK5hUj3SJskPK9J4jzh6Wx1F1poHmrDSmbvfJPEYERNg6ipA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@api-components/http-method-label/-/http-method-label-3.1.4.tgz",
+      "integrity": "sha512-KKLSoTkRDWhdSYAcHQQdsd/F1Gx0Xp+GuyzFZZv+4twjCX7UAoabOrdef6+6IBSlw3bc9ec3npfFr2Ko6D+gFg==",
       "requires": {
         "lit-element": "^2.4.0",
         "lit-html": "^1.3.0"
@@ -304,27 +304,27 @@
       "integrity": "sha512-lWIjd8Wq6tYJmF8ZXyUgQdGq+vhXP7pKY/QcPQdKOn2IXb4/gqTglebtXnxjME41+uKSPQoMSKTEVT/PwX93qQ=="
     },
     "@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.12.13"
+        "@babel/highlight": "^7.14.5"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
-      "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -367,21 +367,21 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
-      "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.9.tgz",
-      "integrity": "sha512-p6WSr71+5u/VBf1KDS/Y4dK3ZwbV+DD6wQO3X2EbUVluEOiyXUk09DzcwSaUH4WomYXrEPC+i2rqzuthhZhOJw==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.7.tgz",
+      "integrity": "sha512-Wvzcw4mBYbTagyBVZpAJWI06auSIj033T/yNE0Zn1xcup83MieCddZA7ls3kme17L4NOGBrQ09Q+nKB41RLWBA==",
       "dev": true,
       "requires": {
-        "core-js-pure": "^3.0.0",
+        "core-js-pure": "^3.15.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
@@ -523,22 +523,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
         }
       }
     },
@@ -627,53 +611,63 @@
       "dev": true
     },
     "@comunica/actor-abstract-bindings-hash": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.19.2.tgz",
-      "integrity": "sha512-Rf5DH43+inBhI/IlmKILQGTYWCWWmK/s3YM+O/wmxO3M38OXFspv4fyIfUYrfBHeYKaq78w64vPH43umw+DOAQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.21.1.tgz",
+      "integrity": "sha512-+EmT/v5hB7La9yXotDZRp7GchYLGO/acg0h9NttZQN8+qp1Llyln+3WriqcVxbbRe1Wqc3DL8Hd9eKAOkAVT7w==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "canonicalize": "^1.0.1",
         "hash.js": "^1.1.7",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-abstract-mediatyped": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.19.2.tgz",
-      "integrity": "sha512-BER87Niq4dqLxfF3JtYCZ1lCHB+MB/N3yNUq5GnInzdisAQBT/T7dwmps1eqF435DyiDS/j0VOJpnPmWV8bRlA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.21.1.tgz",
+      "integrity": "sha512-5LzWccqId3AfAeCPGqPkOiDATXrooXYLn58sNXDRdDUsRpL/jZ6be+7F000ZLTHnDRVCiLCXtb5P7984bBIzaA==",
       "dev": true
     },
     "@comunica/actor-abstract-path": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.19.2.tgz",
-      "integrity": "sha512-0pqfYotFtXIDyNjmqqGyxrVwrS7pNY9R5he3PugilzZCOrHy19Zr8bofr24xTXgEP8VdQR1uD2vE1H43JE/6HA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.21.1.tgz",
+      "integrity": "sha512-9hehsgOSaLDAH4oZccGMEScAiE+4DayTXkjaiQkOobSiHp6dbXgS46vIkWUaSYQGikmgYfkM+j4qwDT33Wl28w==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "rdf-data-factory": "^1.0.3",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
+    "@comunica/actor-context-preprocess-source-to-destination": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-1.21.1.tgz",
+      "integrity": "sha512-yGfNEAJo90XvIMbGZtoip4rR2t28ArfIZmkXo1+E50/Hkp5KFeBwJO/f7ZwH0Svy/5C0wbmCMZpQm+IFV2Cxbg==",
+      "dev": true
+    },
     "@comunica/actor-http-memento": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.19.2.tgz",
-      "integrity": "sha512-3d8cviX1i1CKXkaV0u0C9S/jzmViZTMd3kwVUOwaqJW8EH4dpJkADtxaly32qtRfUp2suNQ/dcG8DlAcHUPNNg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.21.1.tgz",
+      "integrity": "sha512-FRG5CgeOzu8GyaSLtwkLPWX26WWcYKbLx1EpSGJJUq5MBn8Blrcji6G/dwn6hADn4rBI8MErwiA52SJX/p89yw==",
       "dev": true,
       "requires": {
+        "@comunica/context-entries": "^1.21.1",
         "@types/parse-link-header": "^1.0.0",
         "cross-fetch": "^3.0.5",
         "parse-link-header": "^1.0.1"
       }
     },
     "@comunica/actor-http-native": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.19.2.tgz",
-      "integrity": "sha512-/eLeL3/MCuoTpYqMKM4f6VNIgBMtduOHc7DHxw/p6I/mL9mRZp848+MyhKFEN4W4gVk8aKVlMCI4MI52bKXWLw==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.21.3.tgz",
+      "integrity": "sha512-DX/IECNsUpMXNgZyz8e5d/Bpq9PSmlABs7rUqkMVXgqhnOO0KvJOEuWu4P9+ONlkbzqK4O7DKMi6gw3GkKI3OA==",
       "dev": true,
       "requires": {
+        "@comunica/context-entries": "^1.21.1",
         "@types/parse-link-header": "^1.0.0",
         "cross-fetch": "^3.0.5",
         "follow-redirects": "^1.5.1",
@@ -681,575 +675,721 @@
       }
     },
     "@comunica/actor-http-proxy": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.19.2.tgz",
-      "integrity": "sha512-b/yP6TbpEBOac5gtX+4lxF6cd+/mI0WQiYUZGhRQZ2gUEcU0js0Gte9uqz1wCVxIQJnMbOryso3tCVFw/CZNJg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.21.1.tgz",
+      "integrity": "sha512-Z3NvOzZeffZ+aRBZVg3apbVSNjYvAUE49oOL+BrBtT5CuEf+RUOCcSOV/UhpITIFg21/uuyaxvJaT5RmfH+xzw==",
       "dev": true
     },
     "@comunica/actor-init-sparql": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.19.2.tgz",
-      "integrity": "sha512-TUYde50lcJOVbIkY+sJb9B1OuaKB8yvy8oyeNXF8nF3rOdFT0hnjmPcyT9KRKKJXmG7t4ywygDSbyaGqPnlyUA==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.21.3.tgz",
+      "integrity": "sha512-R7auYy7gppLt0nUAc+Y+3mjYmwaLzr02PTx9XGO/ojUi/LnCuU2lrS2Fik90b9N3kg5kDJYN/znT/XHpy5vdGg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.19.2",
-        "@comunica/actor-abstract-mediatyped": "^1.19.2",
-        "@comunica/actor-http-memento": "^1.19.2",
-        "@comunica/actor-http-native": "^1.19.2",
-        "@comunica/actor-http-proxy": "^1.19.2",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^1.19.2",
-        "@comunica/actor-query-operation-ask": "^1.19.2",
-        "@comunica/actor-query-operation-bgp-empty": "^1.19.2",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.19.2",
-        "@comunica/actor-query-operation-bgp-single": "^1.19.2",
-        "@comunica/actor-query-operation-construct": "^1.19.2",
-        "@comunica/actor-query-operation-describe-subject": "^1.19.2",
-        "@comunica/actor-query-operation-distinct-hash": "^1.19.2",
-        "@comunica/actor-query-operation-extend": "^1.19.2",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.19.2",
-        "@comunica/actor-query-operation-from-quad": "^1.19.2",
-        "@comunica/actor-query-operation-group": "^1.19.2",
-        "@comunica/actor-query-operation-join": "^1.19.2",
-        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.19.2",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.19.2",
-        "@comunica/actor-query-operation-minus": "^1.19.2",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.19.2",
-        "@comunica/actor-query-operation-path-alt": "^1.19.2",
-        "@comunica/actor-query-operation-path-inv": "^1.19.2",
-        "@comunica/actor-query-operation-path-link": "^1.19.2",
-        "@comunica/actor-query-operation-path-nps": "^1.19.2",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.19.2",
-        "@comunica/actor-query-operation-path-seq": "^1.19.2",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.19.2",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.19.2",
-        "@comunica/actor-query-operation-project": "^1.19.2",
-        "@comunica/actor-query-operation-quadpattern": "^1.19.2",
-        "@comunica/actor-query-operation-reduced-hash": "^1.19.2",
-        "@comunica/actor-query-operation-service": "^1.19.2",
-        "@comunica/actor-query-operation-slice": "^1.19.2",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.19.2",
-        "@comunica/actor-query-operation-union": "^1.19.2",
-        "@comunica/actor-query-operation-values": "^1.19.2",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.19.2",
-        "@comunica/actor-rdf-join-multi-smallest": "^1.19.2",
-        "@comunica/actor-rdf-join-nestedloop": "^1.19.2",
-        "@comunica/actor-rdf-join-symmetrichash": "^1.19.2",
-        "@comunica/actor-rdf-metadata-all": "^1.19.2",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.19.2",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.19.2",
-        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.19.2",
-        "@comunica/actor-rdf-metadata-primary-topic": "^1.19.2",
-        "@comunica/actor-rdf-parse-html": "^1.19.2",
-        "@comunica/actor-rdf-parse-html-microdata": "^1.19.2",
-        "@comunica/actor-rdf-parse-html-rdfa": "^1.19.2",
-        "@comunica/actor-rdf-parse-html-script": "^1.19.2",
-        "@comunica/actor-rdf-parse-jsonld": "^1.19.2",
-        "@comunica/actor-rdf-parse-n3": "^1.19.2",
-        "@comunica/actor-rdf-parse-rdfxml": "^1.19.2",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^1.19.2",
-        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.19.2",
-        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.19.2",
-        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.19.2",
-        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.19.2",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.19.2",
-        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.19.2",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.19.2",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.19.2",
-        "@comunica/actor-rdf-serialize-n3": "^1.19.2",
-        "@comunica/actor-sparql-parse-algebra": "^1.19.2",
-        "@comunica/actor-sparql-parse-graphql": "^1.19.2",
-        "@comunica/actor-sparql-serialize-json": "^1.19.2",
-        "@comunica/actor-sparql-serialize-rdf": "^1.19.2",
-        "@comunica/actor-sparql-serialize-simple": "^1.19.2",
-        "@comunica/actor-sparql-serialize-sparql-csv": "^1.19.2",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.19.2",
-        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.19.2",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.19.2",
-        "@comunica/actor-sparql-serialize-stats": "^1.19.2",
-        "@comunica/actor-sparql-serialize-table": "^1.19.2",
-        "@comunica/actor-sparql-serialize-tree": "^1.19.2",
-        "@comunica/bus-context-preprocess": "^1.19.2",
-        "@comunica/bus-http": "^1.19.2",
-        "@comunica/bus-http-invalidate": "^1.19.2",
-        "@comunica/bus-init": "^1.19.2",
-        "@comunica/bus-optimize-query-operation": "^1.19.2",
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/bus-rdf-dereference": "^1.19.2",
-        "@comunica/bus-rdf-dereference-paged": "^1.19.2",
-        "@comunica/bus-rdf-join": "^1.19.2",
-        "@comunica/bus-rdf-metadata": "^1.19.2",
-        "@comunica/bus-rdf-metadata-extract": "^1.19.2",
-        "@comunica/bus-rdf-parse": "^1.19.2",
-        "@comunica/bus-rdf-parse-html": "^1.19.2",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.19.2",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.19.2",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
-        "@comunica/bus-rdf-serialize": "^1.19.2",
-        "@comunica/bus-sparql-parse": "^1.19.2",
-        "@comunica/bus-sparql-serialize": "^1.19.2",
-        "@comunica/core": "^1.19.2",
-        "@comunica/logger-pretty": "^1.19.2",
-        "@comunica/logger-void": "^1.19.2",
-        "@comunica/mediator-all": "^1.19.2",
-        "@comunica/mediator-combine-pipeline": "^1.19.2",
-        "@comunica/mediator-combine-union": "^1.19.2",
-        "@comunica/mediator-number": "^1.19.2",
-        "@comunica/mediator-race": "^1.19.2",
-        "@comunica/runner": "^1.19.2",
-        "@comunica/runner-cli": "^1.19.2",
+        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
+        "@comunica/actor-abstract-mediatyped": "^1.21.1",
+        "@comunica/actor-context-preprocess-source-to-destination": "^1.21.1",
+        "@comunica/actor-http-memento": "^1.21.1",
+        "@comunica/actor-http-native": "^1.21.3",
+        "@comunica/actor-http-proxy": "^1.21.1",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^1.21.1",
+        "@comunica/actor-query-operation-ask": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-empty": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.2",
+        "@comunica/actor-query-operation-bgp-single": "^1.21.1",
+        "@comunica/actor-query-operation-construct": "^1.21.1",
+        "@comunica/actor-query-operation-describe-subject": "^1.21.1",
+        "@comunica/actor-query-operation-distinct-hash": "^1.21.1",
+        "@comunica/actor-query-operation-extend": "^1.21.2",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.2",
+        "@comunica/actor-query-operation-from-quad": "^1.21.1",
+        "@comunica/actor-query-operation-group": "^1.21.1",
+        "@comunica/actor-query-operation-join": "^1.21.1",
+        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.21.1",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.2",
+        "@comunica/actor-query-operation-minus": "^1.21.1",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.2",
+        "@comunica/actor-query-operation-path-alt": "^1.21.1",
+        "@comunica/actor-query-operation-path-inv": "^1.21.1",
+        "@comunica/actor-query-operation-path-link": "^1.21.1",
+        "@comunica/actor-query-operation-path-nps": "^1.21.1",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.21.1",
+        "@comunica/actor-query-operation-path-seq": "^1.21.1",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.21.1",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.21.1",
+        "@comunica/actor-query-operation-project": "^1.21.1",
+        "@comunica/actor-query-operation-quadpattern": "^1.21.1",
+        "@comunica/actor-query-operation-reduced-hash": "^1.21.1",
+        "@comunica/actor-query-operation-service": "^1.21.1",
+        "@comunica/actor-query-operation-slice": "^1.21.1",
+        "@comunica/actor-query-operation-sparql-endpoint": "^1.21.2",
+        "@comunica/actor-query-operation-union": "^1.21.1",
+        "@comunica/actor-query-operation-update-add-rewrite": "^1.21.1",
+        "@comunica/actor-query-operation-update-clear": "^1.21.1",
+        "@comunica/actor-query-operation-update-compositeupdate": "^1.21.1",
+        "@comunica/actor-query-operation-update-copy-rewrite": "^1.21.1",
+        "@comunica/actor-query-operation-update-create": "^1.21.1",
+        "@comunica/actor-query-operation-update-deleteinsert": "^1.21.1",
+        "@comunica/actor-query-operation-update-drop": "^1.21.1",
+        "@comunica/actor-query-operation-update-load": "^1.21.1",
+        "@comunica/actor-query-operation-update-move-rewrite": "^1.21.1",
+        "@comunica/actor-query-operation-values": "^1.21.1",
+        "@comunica/actor-rdf-dereference-fallback": "^1.21.1",
+        "@comunica/actor-rdf-dereference-http-parse": "^1.21.2",
+        "@comunica/actor-rdf-join-multi-smallest": "^1.21.1",
+        "@comunica/actor-rdf-join-nestedloop": "^1.21.1",
+        "@comunica/actor-rdf-join-symmetrichash": "^1.21.1",
+        "@comunica/actor-rdf-metadata-all": "^1.21.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.21.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.21.1",
+        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^1.21.1",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.21.2",
+        "@comunica/actor-rdf-metadata-primary-topic": "^1.21.1",
+        "@comunica/actor-rdf-parse-html": "^1.21.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^1.21.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^1.21.1",
+        "@comunica/actor-rdf-parse-html-script": "^1.21.1",
+        "@comunica/actor-rdf-parse-jsonld": "^1.21.2",
+        "@comunica/actor-rdf-parse-n3": "^1.21.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^1.21.1",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.21.2",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.21.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.21.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.21.1",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.21.1",
+        "@comunica/actor-rdf-serialize-n3": "^1.21.1",
+        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^1.21.1",
+        "@comunica/actor-rdf-update-quads-hypermedia": "^1.21.1",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^1.21.1",
+        "@comunica/actor-sparql-parse-algebra": "^1.21.1",
+        "@comunica/actor-sparql-parse-graphql": "^1.21.1",
+        "@comunica/actor-sparql-serialize-json": "^1.21.1",
+        "@comunica/actor-sparql-serialize-rdf": "^1.21.1",
+        "@comunica/actor-sparql-serialize-simple": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-csv": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.21.1",
+        "@comunica/actor-sparql-serialize-stats": "^1.21.1",
+        "@comunica/actor-sparql-serialize-table": "^1.21.1",
+        "@comunica/actor-sparql-serialize-tree": "^1.21.1",
+        "@comunica/bus-context-preprocess": "^1.21.1",
+        "@comunica/bus-http": "^1.21.1",
+        "@comunica/bus-http-invalidate": "^1.21.1",
+        "@comunica/bus-init": "^1.21.1",
+        "@comunica/bus-optimize-query-operation": "^1.21.1",
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/bus-rdf-dereference": "^1.21.1",
+        "@comunica/bus-rdf-dereference-paged": "^1.21.1",
+        "@comunica/bus-rdf-join": "^1.21.1",
+        "@comunica/bus-rdf-metadata": "^1.21.1",
+        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
+        "@comunica/bus-rdf-parse": "^1.21.1",
+        "@comunica/bus-rdf-parse-html": "^1.21.1",
+        "@comunica/bus-rdf-resolve-hypermedia": "^1.21.1",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.21.1",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.21.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/bus-rdf-serialize": "^1.21.1",
+        "@comunica/bus-rdf-update-hypermedia": "^1.21.1",
+        "@comunica/bus-rdf-update-quads": "^1.21.1",
+        "@comunica/bus-sparql-parse": "^1.21.1",
+        "@comunica/bus-sparql-serialize": "^1.21.1",
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/core": "^1.21.1",
+        "@comunica/logger-pretty": "^1.21.1",
+        "@comunica/logger-void": "^1.21.1",
+        "@comunica/mediator-all": "^1.21.1",
+        "@comunica/mediator-combine-pipeline": "^1.21.1",
+        "@comunica/mediator-combine-union": "^1.21.1",
+        "@comunica/mediator-number": "^1.21.1",
+        "@comunica/mediator-race": "^1.21.1",
+        "@comunica/runner": "^1.21.1",
+        "@comunica/runner-cli": "^1.21.1",
         "@types/minimist": "^1.2.0",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "minimist": "^1.2.0",
         "negotiate": "^1.0.1",
         "rdf-quad": "^1.4.0",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.4.0",
+        "sparqlalgebrajs": "^2.5.5",
         "streamify-string": "^1.0.1"
       }
     },
     "@comunica/actor-init-sparql-rdfjs": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.19.2.tgz",
-      "integrity": "sha512-8UWNPF5bCNRMigIJEK0rA9urmv2JTMz7PygB/ZZ2fGCGSuIJjdoeu+CGoQufqZSlloQpWooDqVxqPTGI1x+kuw==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.21.3.tgz",
+      "integrity": "sha512-x2LWKS/qRGZetZGiKGKzKEYr/yb6nEw4KGPbpYo6N4Jp0BvTigiEPYx3HhOaEjeYCONgd/3j3JO5vefFIFNE2w==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.19.2",
-        "@comunica/actor-init-sparql": "^1.19.2",
-        "@comunica/actor-query-operation-ask": "^1.19.2",
-        "@comunica/actor-query-operation-bgp-empty": "^1.19.2",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.19.2",
-        "@comunica/actor-query-operation-bgp-single": "^1.19.2",
-        "@comunica/actor-query-operation-construct": "^1.19.2",
-        "@comunica/actor-query-operation-describe-subject": "^1.19.2",
-        "@comunica/actor-query-operation-distinct-hash": "^1.19.2",
-        "@comunica/actor-query-operation-extend": "^1.19.2",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.19.2",
-        "@comunica/actor-query-operation-from-quad": "^1.19.2",
-        "@comunica/actor-query-operation-join": "^1.19.2",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.19.2",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.19.2",
-        "@comunica/actor-query-operation-path-alt": "^1.19.2",
-        "@comunica/actor-query-operation-path-inv": "^1.19.2",
-        "@comunica/actor-query-operation-path-link": "^1.19.2",
-        "@comunica/actor-query-operation-path-nps": "^1.19.2",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.19.2",
-        "@comunica/actor-query-operation-path-seq": "^1.19.2",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.19.2",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.19.2",
-        "@comunica/actor-query-operation-project": "^1.19.2",
-        "@comunica/actor-query-operation-quadpattern": "^1.19.2",
-        "@comunica/actor-query-operation-service": "^1.19.2",
-        "@comunica/actor-query-operation-slice": "^1.19.2",
-        "@comunica/actor-query-operation-union": "^1.19.2",
-        "@comunica/actor-query-operation-values": "^1.19.2",
-        "@comunica/actor-rdf-join-nestedloop": "^1.19.2",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.19.2",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.19.2",
-        "@comunica/actor-rdf-serialize-n3": "^1.19.2",
-        "@comunica/actor-sparql-parse-algebra": "^1.19.2",
-        "@comunica/actor-sparql-serialize-json": "^1.19.2",
-        "@comunica/actor-sparql-serialize-rdf": "^1.19.2",
-        "@comunica/actor-sparql-serialize-simple": "^1.19.2",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.19.2",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.19.2",
-        "@comunica/bus-context-preprocess": "^1.19.2",
-        "@comunica/bus-init": "^1.19.2",
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/bus-rdf-join": "^1.19.2",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
-        "@comunica/bus-rdf-serialize": "^1.19.2",
-        "@comunica/bus-sparql-parse": "^1.19.2",
-        "@comunica/bus-sparql-serialize": "^1.19.2",
-        "@comunica/core": "^1.19.2",
-        "@comunica/mediator-combine-pipeline": "^1.19.2",
-        "@comunica/mediator-combine-union": "^1.19.2",
-        "@comunica/mediator-number": "^1.19.2",
-        "@comunica/mediator-race": "^1.19.2",
-        "@comunica/runner": "^1.19.2",
-        "@comunica/runner-cli": "^1.19.2"
+        "@comunica/actor-abstract-mediatyped": "^1.21.1",
+        "@comunica/actor-init-sparql": "^1.21.3",
+        "@comunica/actor-query-operation-ask": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-empty": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.2",
+        "@comunica/actor-query-operation-bgp-single": "^1.21.1",
+        "@comunica/actor-query-operation-construct": "^1.21.1",
+        "@comunica/actor-query-operation-describe-subject": "^1.21.1",
+        "@comunica/actor-query-operation-distinct-hash": "^1.21.1",
+        "@comunica/actor-query-operation-extend": "^1.21.2",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.2",
+        "@comunica/actor-query-operation-from-quad": "^1.21.1",
+        "@comunica/actor-query-operation-join": "^1.21.1",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.2",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.2",
+        "@comunica/actor-query-operation-path-alt": "^1.21.1",
+        "@comunica/actor-query-operation-path-inv": "^1.21.1",
+        "@comunica/actor-query-operation-path-link": "^1.21.1",
+        "@comunica/actor-query-operation-path-nps": "^1.21.1",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.21.1",
+        "@comunica/actor-query-operation-path-seq": "^1.21.1",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.21.1",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.21.1",
+        "@comunica/actor-query-operation-project": "^1.21.1",
+        "@comunica/actor-query-operation-quadpattern": "^1.21.1",
+        "@comunica/actor-query-operation-service": "^1.21.1",
+        "@comunica/actor-query-operation-slice": "^1.21.1",
+        "@comunica/actor-query-operation-union": "^1.21.1",
+        "@comunica/actor-query-operation-values": "^1.21.1",
+        "@comunica/actor-rdf-join-nestedloop": "^1.21.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.21.1",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.21.1",
+        "@comunica/actor-rdf-serialize-n3": "^1.21.1",
+        "@comunica/actor-sparql-parse-algebra": "^1.21.1",
+        "@comunica/actor-sparql-serialize-json": "^1.21.1",
+        "@comunica/actor-sparql-serialize-rdf": "^1.21.1",
+        "@comunica/actor-sparql-serialize-simple": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.21.1",
+        "@comunica/bus-context-preprocess": "^1.21.1",
+        "@comunica/bus-init": "^1.21.1",
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/bus-rdf-join": "^1.21.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/bus-rdf-serialize": "^1.21.1",
+        "@comunica/bus-sparql-parse": "^1.21.1",
+        "@comunica/bus-sparql-serialize": "^1.21.1",
+        "@comunica/core": "^1.21.1",
+        "@comunica/mediator-combine-pipeline": "^1.21.1",
+        "@comunica/mediator-combine-union": "^1.21.1",
+        "@comunica/mediator-number": "^1.21.1",
+        "@comunica/mediator-race": "^1.21.1",
+        "@comunica/runner": "^1.21.1",
+        "@comunica/runner-cli": "^1.21.1"
       }
     },
     "@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.19.2.tgz",
-      "integrity": "sha512-MyC//Cl9SwQNKQeaULea8ViU1ehn68hL6CuqqwDHL/0M6lLi45aMFUBs9iK/Vw330uzFjbLjTc1epo1fFb2tLA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.21.1.tgz",
+      "integrity": "sha512-4P4MNxEfGZJYE4z9OXTOWWykz0w3h2dtw8p8pLDcXplRIh1U9BaS7rtYVl953PvNfLsc1DS3Kpn0MGEN3NJdGA==",
       "dev": true,
       "requires": {
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-ask": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.19.2.tgz",
-      "integrity": "sha512-ogRkDwuPxDBRV8By20OHSkB89MblNM4YVfkMT2pPDhWrPojKGQVvedi58LpnfWX1NmTN63fhm9F8TyaG+jwsew==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.21.1.tgz",
+      "integrity": "sha512-23sE2Kr+z5UHcgQ+8xGv9dJPxBnv5eavWqSkgIESWEVzBfogvJQ8mMt/2wl1+bvdip0Nme+MJ9/hUYTMqr//ew==",
       "dev": true,
       "requires": {
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-bgp-empty": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.19.2.tgz",
-      "integrity": "sha512-Lbv7XC1Jct0FMIat4ZwVH73M2KttaSKbiVCN27ef97HTlveHS5IJ0TXUBcf/sn3YGXhQcaF9zFiLozZ9cD7o0g==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.21.1.tgz",
+      "integrity": "sha512-Y1W7ViP/ZRlcOrWJk7Y2HsU2+qS+qc1A8VGfpKzhwZaIbBS6FUiQnAHkH8eDrO9RtET+zanKxu37+Jnj2n6MyQ==",
       "dev": true,
       "requires": {
-        "asynciterator": "^3.0.3",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.19.2.tgz",
-      "integrity": "sha512-KuyPkY47MFBYcZIwE2shJYTpd1ERGOLuwEVG3UOXz/ON6tosklQOAbuGHe0bFk0fZTrM2e3SLVdPMeWaetf7QA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.21.2.tgz",
+      "integrity": "sha512-7QTQiHFbdZcTxv35SddFzorBuvoQio7KXY/z0hU/JoFr0vx5qtZQFXwrl0dt41xqnJkFGcv1s7U3Zx6Rc1uQZQ==",
       "dev": true,
       "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-bgp-single": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.19.2.tgz",
-      "integrity": "sha512-Z9mdfGg/blqzh9wDEusnwwpTpP7Eb3GdbIOAxaMzIe3fo3PDuTadariXPzliho9tprC1dF/JN78i/1QM5MYqUA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.21.1.tgz",
+      "integrity": "sha512-a4xupJleAxeyxA+m8Ghul6AtfBRCMWv5Ftr5DCcZF2j96UCREnSnD1OuMTJfsf7hWV+H9TGJ3gtK1IinB1LxAQ==",
       "dev": true,
       "requires": {
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-construct": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.19.2.tgz",
-      "integrity": "sha512-wNktY1yUVFCQBqvcr4xD52hlMmDzrB0VOJ9aEHQdvjmCs4P2AsLCG5Ty+qiz7va3HC1nT1qV4qRNLkeUYS93GQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.21.1.tgz",
+      "integrity": "sha512-b1baZhA0py1JEI9xNGtEcHt0VJOMMBkA5tC8ePabNnPXc2Bwn29grzb+PQwkf32rU6tRRgJHRua5EcIZqDRcqg==",
       "dev": true,
       "requires": {
+        "@comunica/data-factory": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "rdf-data-factory": "^1.0.3",
         "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-describe-subject": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.19.2.tgz",
-      "integrity": "sha512-AVNiPI/k6HM+fSRxcTodsHLld+lADxzKDnjUGk4ckcWSqVsmzwlWUJ1DZfp8xqVj/3uWkIeG1oaY8h5Ph15ssg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.21.1.tgz",
+      "integrity": "sha512-KGACWNnYRQVqPzaF1iyYiivFfAucnPU6yaJ0mUKoSiMXEwVCIHOZL8m29TMxHqc5AI6C/AZlvddT1MHQ+cFOXw==",
       "dev": true,
       "requires": {
-        "@comunica/actor-query-operation-union": "^1.19.2",
+        "@comunica/actor-query-operation-union": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "rdf-data-factory": "^1.0.3",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-distinct-hash": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.19.2.tgz",
-      "integrity": "sha512-LO+hAW0tGRthAUKOkUM7ODjIsUbdNgPh+3cdVr4vkb2OcI/bJy1i5owIKUotepg8SuwekjDgOz0DxF2Mr5rjtw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.21.1.tgz",
+      "integrity": "sha512-DiIwjep3FlUyDNqyenRyN/CxGKOFxfIXDsOupYpQq0H5KSYEVyyYNJao4F+ZvdcLHoSRJkLVW+GTTb8zCbEGbg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.19.2",
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-extend": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.19.2.tgz",
-      "integrity": "sha512-6n2vY/QvOc4QreT3I/yf8jVryJgOo6czAGL/UelqS00BO/uOwRK1TjUsylGzeCTtp0w0j7SF6UiCp3PueIAi5g==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.21.2.tgz",
+      "integrity": "sha512-dXL7Lrp09CZUU8T6EMXaf4eAMzcSsMpIS5XvU+LjF9u9vMjkTU2EmTpeW5l0WoWQhy9woqL0wTceckfGF3nQRQ==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0",
-        "sparqlee": "^1.6.0"
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqlee": "^1.6.2"
       }
     },
     "@comunica/actor-query-operation-filter-sparqlee": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.19.2.tgz",
-      "integrity": "sha512-J+YZ8jzgpXVuKOJt1wEXiu5ZuynvSJ7USVqPbv3rqgmA86cXKL/ko5JNf6aT3kGIkHsxmXHtxKYfZ0xv0g07HA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.21.2.tgz",
+      "integrity": "sha512-xPqalmx2a84HzdZ87YVswJYf05Uj/AyRXmtQfHB2XNULzReNLyq56LUs22tOqWDuthzgL/0yTKtzYh8d8J4WVQ==",
       "dev": true,
       "requires": {
-        "sparqlalgebrajs": "^2.4.0",
-        "sparqlee": "^1.6.0"
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqlee": "^1.6.2"
       }
     },
     "@comunica/actor-query-operation-from-quad": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.19.2.tgz",
-      "integrity": "sha512-bao1/9lBBOHTnkORdfxpRrvvxHoJGEBTH06/E5CQPod7SkVlYs4cSBqy8UikkqNpehoXXHgQsOzncue8vlu2rQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.21.1.tgz",
+      "integrity": "sha512-fJ2qk7jb5vouiCYI/S37O9gQg8Ol5Y5vmgzmVj//aTV7/oobI7j0V3hRyrM7pN6RhKK7g9daxoO1rqeZkUBQ7Q==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-group": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.19.2.tgz",
-      "integrity": "sha512-1h32gBva2Dd1SIbnhoEQizCzQkhRxI4r0lotDTtiijF/Wl/yvqc4FSaJ5ieeEVKSlPLpxmAvRKiGoGVT1FxA5A==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.21.1.tgz",
+      "integrity": "sha512-oiZEJH/z4sEtk7ImT8yyBHzlHJtvgcocQVoaGJGU+dor6i2qTTMULPdyzYnAYS8bJLczYnpnb5TDakGGn6ijQg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.19.2",
-        "asynciterator": "^3.0.3",
+        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0",
-        "sparqlee": "^1.6.0"
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqlee": "^1.6.2"
       }
     },
     "@comunica/actor-query-operation-join": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.19.2.tgz",
-      "integrity": "sha512-va0/UJyVojEDnmXON16zre5i6zhX1bFPeA0MmndTMxVaUSHPpknZkRq1VnSKxE6jb8bejVEfjgcU9JxRnPd+uQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.21.1.tgz",
+      "integrity": "sha512-x3IwZ61R/nVIgG9+nCVJeaeJZfmfFuFfgdDi2wUFrAPH3C2ebJLinOOiJ/BMR9qYUjxHXm/3R2r35DZyUM03yw==",
       "dev": true,
       "requires": {
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-leftjoin-left-deep": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.19.2.tgz",
-      "integrity": "sha512-j3Ah5oz+K6m3Tj+mBLK5qt20BKnMimEOKy1WNic/Z48CshJU8lH/jCivTOrg/AYjx3+5fi4JfsKEVY/o8olHyA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.21.1.tgz",
+      "integrity": "sha512-qUcCPnQzwSVBVipPo0fnQeJt8EWWaBzZ8ujFE9zwlrhuTlZtS/XeoIhtKyIB3LoBx/D5gIGlREdFtz0wTFdJlQ==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-join": "^1.19.2",
+        "@comunica/bus-rdf-join": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
-        "sparqlalgebrajs": "^2.4.0"
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.19.2.tgz",
-      "integrity": "sha512-KYG+3HeBzzY2INVHERMvaCjuymxjfHvrmfmhrjidWzHsjyaEefaDKaZcp6zIRBGRKmHsN/+03c6cVm7ZMru7wg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.21.2.tgz",
+      "integrity": "sha512-O82jBCmkeSy8JMaKfZOqnn3QYHfj/0Z8CRSfYsGV83xjVuXv/hg0QogKmoW9Vl0wJRoVLb/ydpmVXaBFzH3rnw==",
       "dev": true,
       "requires": {
-        "asynciterator": "^3.0.3",
-        "sparqlalgebrajs": "^2.4.0",
-        "sparqlee": "^1.6.0"
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqlee": "^1.6.2"
       }
     },
     "@comunica/actor-query-operation-minus": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.19.2.tgz",
-      "integrity": "sha512-UdsMEUzjEyLI7Zz9uAAcRwdQgFXNpKA7Kr/9T8bIC65Ta3g1r2WmOm6Bf/NIeAaoB0gMTm/vZObj2Ey5+OSIWg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.21.1.tgz",
+      "integrity": "sha512-3UcQMn5tiAwIRxilfJuhKRFYKYrTsGHyJF8EE4OJMhbPZIZWKlQG298H7u51AOYtTOrmIgU6Wny2U8Ju15IM+w==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.19.2",
+        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-orderby-sparqlee": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.19.2.tgz",
-      "integrity": "sha512-jB9UE+wmOPvZl00BjzuRKv38/4iXcExhhgSB8UetG0XM2jmaz68XjJwHHOntoAD+XO6jyKR/cIIriVYTMfu7JQ==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.21.2.tgz",
+      "integrity": "sha512-datwGMxBhAV6jDPENGmOJGkC9qTGCaOQijWrd0AbeYlThD3GaBeGl+n86xd3sfY3AwGQrkle2DwEhjliXPmtng==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0",
-        "sparqlee": "^1.6.0"
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqlee": "^1.6.2"
       }
     },
     "@comunica/actor-query-operation-path-alt": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.19.2.tgz",
-      "integrity": "sha512-5Lqtt5qfnkJx+vL0g7rZAXoA4wEWCjSmkhTLWdZU+4+YvXhfY0S3aQ8W1Ik/Q93O5u+pRFje1z49AMpWuk83MQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.21.1.tgz",
+      "integrity": "sha512-YqvCX7fAYGqJnSEDOzF02niFrNWSjHoXF1UOF8uT3fFa+iH9lcnVbWQUkddNieIqlwiLw/BEufnx24XQiogIQA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.19.2",
-        "asynciterator": "^3.0.3",
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-path-inv": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.19.2.tgz",
-      "integrity": "sha512-R4FJAQAMkIqTNxX4aLxvkx2UeQXGbBle6kWNC9z9LiOaBorXERw22xTOlG9viNkn+3iRPVCIcxJyJ+Lw+msTTw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.21.1.tgz",
+      "integrity": "sha512-PZuAc50w9TOgO1kESMv+P/wLZrHZMlYJSKpTrr+RikM7pM0t3VemI01qDdL63gCY2UxGh3kTCwYkv1qOx5JZwg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.19.2"
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1"
       }
     },
     "@comunica/actor-query-operation-path-link": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.19.2.tgz",
-      "integrity": "sha512-+efbj6CH81KFXt4oy4PXM23HoOSj9SEvxPG+l4zmpnrjzsoGgpBT21bZeqwuGUYnCXmqCkljjMvEv7w0UwfA9w==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.21.1.tgz",
+      "integrity": "sha512-aScmnhisOVmRYUPWOjbzxMO4DHzGmqaRKvoHqVMEF9tgAX5E4nmJ1XvFBE9vzuvY1aBxPm5sHnSYlEtUeGa5Mg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.19.2",
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-path-nps": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.19.2.tgz",
-      "integrity": "sha512-j2R31+DtnDjWpzY6SNv7xezCzhQ3HuGLuAnwqpy22wQgLSev7D8jbe/1NSl9GTQZL62MnF39JrHLc0bSQwXWQw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.21.1.tgz",
+      "integrity": "sha512-HDw1AoshhNiKWeNcACmSwiSquf0PZkPjoN3cTjg/8wOQz3Yf/XEQfdCIJ9R2vMHaIArMlprq5p4MGrf23RkMcw==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.19.2",
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.19.2.tgz",
-      "integrity": "sha512-0c2EjNb7gSwyRxD6VMhqefrm3trOAVePIxWui7Dc0R8/Y50s9rZAmM9C2Yv+8V8eRgJdqPpZrDa6ck+CWLnrUA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.21.1.tgz",
+      "integrity": "sha512-PxOhNKSrgfF5In7DBQOcfZKZRs9o843Cn6Shs1n7Gv0Qa4kbHRFssRe2bL65WTHVNiByghOgOYfUERJfNz0IJQ==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.19.2",
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-path-seq": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.19.2.tgz",
-      "integrity": "sha512-rGuTL2JsbwXVsplIhrZgbilmpeirDTBXOETkPJHcwsVtZV6MBZGNfVTK36V6bHUJXQAZJpukLuuO27SaUMwVqg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.21.1.tgz",
+      "integrity": "sha512-c1PRbRf18xknqeAMC96FkPzc9Tbz7zGU3FLrDI92Mu5cAcABhAwev3BM1T19UhI/cNkgGkXNa61SkWLVND3oGg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.19.2",
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.19.2.tgz",
-      "integrity": "sha512-cJI7xCyb1j9VLeyEnGtOfNOi7yvIbJ+Zm7eztG/jHRgBWEKDfVrVhlSKrctMvZjFzvbZBiYuMdrCE+56mXydSA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.21.1.tgz",
+      "integrity": "sha512-NzgKiD1w+gq/muE9Bd4tQjxfKnVwWm9LMlP8ZBSdZfMQmj4vNAHQhhVHjVPTflElwtB47UlqlRQVxWlP0O79JA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.19.2",
-        "asynciterator": "^3.0.3",
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.19.2.tgz",
-      "integrity": "sha512-r/hn3jUVWHExyICMyeobVvyrVIvZAB7SpB00nO1r1xx/JdJdUAlPP72oKioX8UcKcT5WVt1D3b3+6ZFwaQKz1w==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.21.1.tgz",
+      "integrity": "sha512-WSNAAlwYm5FBoSOrxX9rZ2VbEQi+k1od738UV4BgoK9YOKZrgDKfj0KhX4niFfnJCjQHAM3iX1GjpsmkYthlSQ==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.19.2",
-        "asynciterator": "^3.0.3",
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-project": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.19.2.tgz",
-      "integrity": "sha512-u3X3Vc9Sj/s5LgrFoymaFXc6fyI6XAO7XQRVpO+1F5jKmY+oFQwK/jRi6J6JluTZNtjlmzfIyY0EsHoRSMnPfw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.21.1.tgz",
+      "integrity": "sha512-NTxKHCQWUxotmOnp7K4l2r1NbUQv2Ei2VOCfXd99Ix1CDrNlNt0bTDbKjDaQdwFm+wwDM2IoqmkbeLgD4KU3yA==",
       "dev": true,
       "requires": {
-        "@comunica/data-factory": "^1.17.0",
+        "@comunica/data-factory": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "rdf-data-factory": "^1.0.3",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-quadpattern": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.19.2.tgz",
-      "integrity": "sha512-LAKMVsaMJP1uZUl8aFWnFg1pbhIwu4b+CRvIj0hHf7iaC1ng6wwRLIDF7c/6gDlzsDD9BRZg0r0XmJQPF0/DFg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.21.1.tgz",
+      "integrity": "sha512-5HmXPT1aU9jpdVaPXeDr7OtKsArQ9xzyZb4KjdfJJPJh5GB5eRX22rA/3xJtb3eugQohNd4miCd8FsfNKx/Lmw==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-reduced-hash": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.19.2.tgz",
-      "integrity": "sha512-owHWzME+V9uhsJrdU7jKJCWh4wfGrGL+iuf+wlFvbSp8Z2EZdRYAtymAvItCmFzVeTTGlPlff89xdWqg/apxLA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.21.1.tgz",
+      "integrity": "sha512-MDtwwFeP0+CuloFxDtWXbdAsJyNuN+RLYPUbesBtusH9SmeUQjEVopLHpDp3QsZJB02HLeaz3pLMlVZTwxOQWQ==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.19.2",
+        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/lru-cache": "^5.1.0",
         "lru-cache": "^6.0.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-service": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.19.2.tgz",
-      "integrity": "sha512-YA4T/dO09HecfNri8JRveg6hRst79Wfb5dZqmBshj4zh/zzZFABDWI+XMXbwbX6wuG1q7wJDCRzO2Ku3X1WV6A==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.21.1.tgz",
+      "integrity": "sha512-ffIUCnMSTOshFVsVvI8RYTvo3l6nyTinVkl2sxo7O4Cty3jidxA4TScbWPue64sZbbuGvjPb2+2CTvHII2uZjQ==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
-        "asynciterator": "^3.0.3",
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-slice": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.19.2.tgz",
-      "integrity": "sha512-Cq+uBRQKzbOa5uJUCP7O00lyPQ6TtYn2dOT+5VCdnjAbuk3DyVqR614tih3SAgA5LRYTUxfX+WePlvOoIq6eRA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.21.1.tgz",
+      "integrity": "sha512-tuV+ccKKSFL5xnrKVKoJohXWxYOy/T+hW+dS+EOA0cTsluYJSd3Pj3JSE7tfxCRjTn8rOtgqOve3rk8NVkRHYA==",
       "dev": true,
       "requires": {
-        "asynciterator": "^3.0.3",
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.19.2.tgz",
-      "integrity": "sha512-VC4VLMA9zAckci3S/Smw2ebQe0JJoDB1La/EcSidI1RJNittlf5fw79wbCYGxZuTi0tCmTCYRyarMqDZpQrp7Q==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.21.2.tgz",
+      "integrity": "sha512-Zyy1SgumHMQKziQFujgckXWG46Un1clGLgNObf1tTy4Gj66kWzO8YNZ5nuXVbFY6D1DyAis4vzsZvV1ieKX7gQ==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
-        "@comunica/utils-datasource": "^1.19.2",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@comunica/utils-datasource": "^1.21.1",
         "@types/rdf-js": "*",
         "arrayify-stream": "^1.0.0",
-        "asynciterator": "^3.0.3",
-        "fetch-sparql-endpoint": "^1.7.0",
+        "asynciterator": "^3.1.0",
+        "fetch-sparql-endpoint": "^2.0.0",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-union": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.19.2.tgz",
-      "integrity": "sha512-4swo5gN/XzqPIPEzw2rf5EsbB7jqywS56pjz1R4zt9ar1vHGgsiwkngEM6iWfWkrFbZF/gUnSQMIo/F9oLtPPg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.21.1.tgz",
+      "integrity": "sha512-KnFTTt3Eem/KP7J3jt67WryjUb3Ma67Zjs0uvSavhEZ8fDSEtMpU1eEK8WEOvrLPm2gh8u4oBNJ7A1VQbRV+Hg==",
       "dev": true,
       "requires": {
-        "asynciterator": "^3.0.3",
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
+      }
+    },
+    "@comunica/actor-query-operation-update-add-rewrite": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-1.21.1.tgz",
+      "integrity": "sha512-dV0yT36fUBJnLSQuwcdGVr8qyoL0Tu5jbL4ONbhjqAxHP8e4wlqwzQRiZku5ScqgoBmuZ91oeFXnIoQ2EhjCKg==",
+      "dev": true,
+      "requires": {
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^2.5.5"
+      }
+    },
+    "@comunica/actor-query-operation-update-clear": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-1.21.1.tgz",
+      "integrity": "sha512-YDhigDrIMLYZeUIJ1uvs5F9HLWPs1+AcYuq6FHrYGhqpqqQ0PyUDsl+LcoI67VvRidLIu3/viecU6Bdvb8Gt6w==",
+      "dev": true,
+      "requires": {
+        "rdf-data-factory": "^1.0.4"
+      }
+    },
+    "@comunica/actor-query-operation-update-compositeupdate": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-1.21.1.tgz",
+      "integrity": "sha512-9odx0936F9WQQZ+K7SChzwDkjyIolwOSTIg7epsp/Z+cltp0ZeLMEJvr9ZYgYf5qxZT4SHxiQ+sjfAYffVSRnQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/actor-query-operation-update-copy-rewrite": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-1.21.1.tgz",
+      "integrity": "sha512-Ou0oL0e7FHRfWB/3DVko/4ESoxCN9Ue6CasVxUOAN2z9FSMYPV9SF8AgZ8R6LeSwHKeIwXhv2sGg6LiJucxz2Q==",
+      "dev": true,
+      "requires": {
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^2.5.5"
+      }
+    },
+    "@comunica/actor-query-operation-update-create": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-1.21.1.tgz",
+      "integrity": "sha512-RgwdyjIOrxldqNndzrONRIjPBAXThyxxGtr8xjB7V7q9TlnLVXlAAD7PrSZcH8MLY0VoPNMOCVR0y9t4TKBt0w==",
+      "dev": true
+    },
+    "@comunica/actor-query-operation-update-deleteinsert": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-1.21.1.tgz",
+      "integrity": "sha512-BidV3Mn1w4ieQvNgVDHS9hwuyx9Wy+fB5+btuNEh9JHdpkHDZlN0vvqhpExVS1a7bx9cdQUpwouipR6THQ5veQ==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-query-operation-construct": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0"
+      }
+    },
+    "@comunica/actor-query-operation-update-drop": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-1.21.1.tgz",
+      "integrity": "sha512-v//e5tqsqFsu37A+GfCHBqbOfDhI7J8uRjXPZ8VnuapMeUfLQTZSVGf2xQ+/FD/UDp3/gpERKVC7cRXPzoWEFQ==",
+      "dev": true,
+      "requires": {
+        "rdf-data-factory": "^1.0.4"
+      }
+    },
+    "@comunica/actor-query-operation-update-load": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-1.21.1.tgz",
+      "integrity": "sha512-ql4eAZhwIqF5CjzCcU6vmRaxHwYJTXnLsseBmQzJrgvKNxr3ols0E6sc4tia1IIeRTmHmOz+h7AZD4uyWw+Xrg==",
+      "dev": true,
+      "requires": {
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^2.5.5"
+      }
+    },
+    "@comunica/actor-query-operation-update-move-rewrite": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-1.21.1.tgz",
+      "integrity": "sha512-T71U+wuWxzpYbVmJ0Sb/FFQY/Vh8nvCDgih4GOFPEI2UhZFYsQ5ilGy8a5xBPeuuuSWvYEvL/+VZPeIp8GZTjA==",
+      "dev": true,
+      "requires": {
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-query-operation-values": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.19.2.tgz",
-      "integrity": "sha512-JZfuffeWhX/Ss6FDeQBR+H/OtCh/iI4nl+ElFRjfJ8OfHU/r5cU7R5ecXb+U0cZ780/PltgfKyq6wtannRYnLg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.21.1.tgz",
+      "integrity": "sha512-BfDg+Lg4snRI4CLdopztaErd040P7y4sflriDCMHEoqVVQuha89Scddcx3ClqOtJx5mScYmjGxkt8ttQwx5MHg==",
       "dev": true,
       "requires": {
-        "asynciterator": "^3.0.3",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
+    "@comunica/actor-rdf-dereference-fallback": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-fallback/-/actor-rdf-dereference-fallback-1.21.1.tgz",
+      "integrity": "sha512-iXaC7/jUWMJQKoNa9Hm4UouXTJfER/jyK7HQ0q9ddkLvXYTWwcltnnLxs+dXQRbpUZm8NvP/LPUC3H1G85Tzwg==",
+      "dev": true
+    },
     "@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.19.2.tgz",
-      "integrity": "sha512-2/b6YgILmYf+tR5GZ/3JRGxY9xqExVJnaRx6qOJ3ay/98MRRjhQxtDxAIClMZNFlc+gwJb1T5vPoX1H8dnfDNg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.21.2.tgz",
+      "integrity": "sha512-TLQLw6rKkcslHyyYFpELy+Oc9KuLZbqxiOpMUQQqfi1/yLT/8C0dvQSTl0dOtKombSn4N3aFsA0ycbjuPWi01w==",
       "dev": true,
       "requires": {
         "cross-fetch": "^3.0.5",
@@ -1257,46 +1397,49 @@
       }
     },
     "@comunica/actor-rdf-join-multi-smallest": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.19.2.tgz",
-      "integrity": "sha512-Vr2ZwBsKRY3TMRta+AI009zrdk+1pUrgsyw4kUQmQ4EbzJQ1VfoUQ8sg23A8rDNAIcBdq+1skHRhWOxfPAvaiw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.21.1.tgz",
+      "integrity": "sha512-3PmXF6QgNmhYLm0XrN3Fdyr632YwHmv/kngwLdIRZAFyGBOY41vEoyLzbSiQNBCmdT1lJ1qX4tl3yVQkskPCoQ==",
       "dev": true,
       "requires": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/mediatortype-iterations": "^1.19.2"
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/mediatortype-iterations": "^1.21.1",
+        "@comunica/types": "^1.21.1"
       }
     },
     "@comunica/actor-rdf-join-nestedloop": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.19.2.tgz",
-      "integrity": "sha512-Rt7FJ8s+HMMiY3F4qoXL4/WX0JGEFktfFv6o2OZyTrJ+T+CRYhw/ikQX0upVZpdT0xqjGxRzAZbdVfyAezHyNQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.21.1.tgz",
+      "integrity": "sha512-19zZ7rgPxWgxKJcN2HeimpGj7TCx7yYLWDyhKw9KPra/7Ogc8bKhawOINCEqWdyi0nACQO9G/gXCpakjUmnd8g==",
       "dev": true,
       "requires": {
-        "asyncjoin": "^1.0.1"
+        "@comunica/types": "^1.21.1",
+        "asyncjoin": "^1.0.3"
       }
     },
     "@comunica/actor-rdf-join-symmetrichash": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.19.2.tgz",
-      "integrity": "sha512-uXgh74oDrbEqflgUzEadwKu/X4EARZUPkLkHSyHgTVkwwlr2uNhvNmve931nXjt0OBZ80THiVEcYit4roHd8LA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.21.1.tgz",
+      "integrity": "sha512-st1NVQ0g/ODC+qf3z+QANNYj5Hngqlq3D+cxI5oswFeTnKVFWWB66DjzO0oiqE3YuUu0aqNoV5Jty4iTyBieig==",
       "dev": true,
       "requires": {
-        "asyncjoin": "^1.0.1"
+        "@comunica/types": "^1.21.1",
+        "asyncjoin": "^1.0.3"
       }
     },
     "@comunica/actor-rdf-metadata-all": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.19.2.tgz",
-      "integrity": "sha512-2oTtZOUFs2PyILht0J6Ma9/x5srjyvijbobgCSfcrENkv+r1wRDriyHMOfiuWLlvFlksumJ17gerp8iehPorqQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.21.1.tgz",
+      "integrity": "sha512-YbDuyOrBcQ9dzW0WTJ26wr35QxddohjuZ0p7Zs1wNFr6uImkkcL9C12h9QJOA4SRa1//u9DhWxni8AMmn6w/FA==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.19.2.tgz",
-      "integrity": "sha512-3Qt7NhG0AJUnDM7537G8lyryPdykpdIqGERs0EEPzvfOtiCbPXoBtvVfj82hdIcIXKEgqrpgyt4CuJoGGSK6zQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.21.1.tgz",
+      "integrity": "sha512-pfZeKwKaYR73QhGHrURGE+cNB5qavKaW6F9EnjkE44maTvyflW8RWog6p8s5dD20FLCKq/OLyLpqBNQ7Z1y04Q==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -1305,85 +1448,92 @@
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.19.2.tgz",
-      "integrity": "sha512-7sD2BNiyDhjjUmavmy0xUX0EgI5DNacKUa8xX5xzZj5WC/glKtSFMO/nUpiqzosmdaZ3vryICm4mXVFS3eKmRA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.21.1.tgz",
+      "integrity": "sha512-y7U/hQ/R7iKDa4Y+XBsyjaHVbpuzgq6Zs46Fm1u6nI6ln4e6Cs3sDHZgegzcZ/Orul5+vn61yb0hhO1JxJlOAg==",
+      "dev": true
+    },
+    "@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-1.21.1.tgz",
+      "integrity": "sha512-mii4UIX2xwAo2SLQsJ1UqS8rMnnREsXQfti+6hAJ81hu4I77YVnC8MJ0McripzqHLXukGPepJlYwNZpbl1KrhA==",
       "dev": true
     },
     "@comunica/actor-rdf-metadata-extract-sparql-service": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.19.2.tgz",
-      "integrity": "sha512-hVr1RPf+kryRkDGVwK1DX3mwskVtJhDI8Jhr5u2Y0CmtvelucNpo8mivvNgV5M5M4FhX+4jSUp17ndnJTizHUw==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.21.2.tgz",
+      "integrity": "sha512-3sO7giO4UroalkIHGU3KlFQk+OINOvUx3eCdD60nZUvxRBlfUKkSMyYmCbGEY0O9LWvVAXWclnwlKfI+C7mPdQ==",
       "dev": true,
       "requires": {
         "relative-to-absolute-iri": "^1.0.5"
       }
     },
     "@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.19.2.tgz",
-      "integrity": "sha512-mh50SL2p5+eo9CbNJOysUe0C7ThoA8x5Y8994Plo3p/c0HfT2G8KsTM/vyIYIkKr54lDZ7I8izmd41dDicJ49w==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.21.1.tgz",
+      "integrity": "sha512-aBinVc2+fedm0KzF6NmmDRSGaZyJhPimeTpiQh6Vrm7vPw+J5SuqfXD0AccLJKcWvGMbiRMagWP+lLTBjiMGWw==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-rdf-parse-html": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.19.2.tgz",
-      "integrity": "sha512-E7eJH5CR9cvYoaK78OwA8wkc46FsU7hbDHIkXy3fKktooXOcOJxoMU3+0xZ0n6qFRRzMQjzNzh+KnR+0ZgZWIg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.21.1.tgz",
+      "integrity": "sha512-eZUExtLtC28nEMrECL2g3kmZjLmuY/Nu7S9p5NyvI60cwEjj1Rbf0aM9xqWLG5vuCiSKQz7MUobQ92WxtG6RHA==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-parse-html": "^1.19.2",
+        "@comunica/bus-rdf-parse-html": "^1.21.1",
         "@types/rdf-js": "*",
         "htmlparser2": "^6.0.0"
       }
     },
     "@comunica/actor-rdf-parse-html-microdata": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-1.19.2.tgz",
-      "integrity": "sha512-i+FfdPRsd1wT5yrnFORo1eFbL2G+YyeG3dQtC7bEuTf3pW9wXJCUWarLZ0dBbCK3WaPR+J+zdM+fss4j++0bNA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-1.21.1.tgz",
+      "integrity": "sha512-50EjJ0HYiCdKEb2nebULLGkqLk9XZeLLSPCMDo+4Est65dGXcLkFPerBPTIlcrpOMmVXLry8F7m+fAtDQxUcmw==",
       "dev": true,
       "requires": {
         "microdata-rdf-streaming-parser": "^1.1.0"
       }
     },
     "@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.19.2.tgz",
-      "integrity": "sha512-Sx9vDZwHnXbcAkKOTQj0mIeablIQO1W6O92Vl1u0eStuaMyB2xBIFnPDpHpM9oQ8Yg14xwdGnSfqfCRW1Ar/mQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.21.1.tgz",
+      "integrity": "sha512-37whUUn3LsvCV/kj37/ztAnBjGqKdGP8fLUpD3z8vDOg3ArhktPvWn+cB0ssU0DKSzsCTnCNujS7QoVyINPxJQ==",
       "dev": true,
       "requires": {
         "rdfa-streaming-parser": "^1.4.0"
       }
     },
     "@comunica/actor-rdf-parse-html-script": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.19.2.tgz",
-      "integrity": "sha512-GgJF1cZpFWJ7ga3g/BxuxpPQeASf07eZd3TiLRlQ5Mll4sVVqU9CO+oebQXbtnzJYnxPrSP85YCP9Ez9TnfFkQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.21.1.tgz",
+      "integrity": "sha512-cM06ZEVpgj4/fLFrM8alRi0a4kh1XVY3vwWOyZXnkjVkIKp36Nc17Pw4+vM10z7D+x5VI/mZc0tGMohr8u7dcw==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-parse-html": "^1.19.2",
+        "@comunica/bus-rdf-parse-html": "^1.21.1",
         "@types/rdf-js": "*",
         "relative-to-absolute-iri": "^1.0.5"
       }
     },
     "@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.19.2.tgz",
-      "integrity": "sha512-t2rLKtiUV0ku0ZkxjzIDUfPV/SOfeYmdR6DRBDMM/b44xda+fxeSIsYEsxjNMsz0GWUppgWi/+dmBbioO38qDQ==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.21.2.tgz",
+      "integrity": "sha512-YUiYo2EJ9T1oUGgBwzzPRjXT+cd/xckWbtfYBzr7RugXeKjrVai8atnV1OsPc0u5iPZCTkiVCO9sI/Q6M7ig2w==",
       "dev": true,
       "requires": {
+        "@comunica/context-entries": "^1.21.1",
         "@types/rdf-js": "*",
-        "jsonld-context-parser": "^2.1.1",
-        "jsonld-streaming-parser": "^2.1.1",
+        "jsonld-context-parser": "^2.1.2",
+        "jsonld-streaming-parser": "^2.3.2",
         "stream-to-string": "^1.2.0"
       }
     },
     "@comunica/actor-rdf-parse-n3": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.19.2.tgz",
-      "integrity": "sha512-IReAuHq1H0xNOMO0fd1mbbkgnfw1VS/Q5+hK0WJA3j5lII/nrSKRIbmdyP6jYLNHwj2F3i6aGTCRr9Z75/86kA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.21.1.tgz",
+      "integrity": "sha512-SFx/hkY0yr/TxfVdEecVg3DY2KOWPeGfM288CjDQjogx6Sxb6JuF9JaipNX8/twKVdBefGS9b1S9EyKpcr99Zg==",
       "dev": true,
       "requires": {
         "@types/n3": "^1.4.4",
@@ -1391,140 +1541,136 @@
       }
     },
     "@comunica/actor-rdf-parse-rdfxml": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.19.2.tgz",
-      "integrity": "sha512-vC4RVTe6RTsRD32ZJR5NEOUGiHACCVvlO2/NUFy3g9/H6aQdiKen/iAqfDo03jq4yJO2UTFx8zj5l5fLvzL9yA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.21.1.tgz",
+      "integrity": "sha512-fv5+DF5LagSJUayyQm7a917XQ9PNUfJVh2bqO/NlVfESXO8OFUAIySefW+j1y1JA0fpa5v1OnWTGAfdxGKnrUg==",
       "dev": true,
       "requires": {
         "rdfxml-streaming-parser": "^1.4.0"
       }
     },
     "@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.19.2.tgz",
-      "integrity": "sha512-y9dYBawjAxBfHZw3ITByq/+N/pkLmIqUcXc9ypiQEx1C2iZvlkgKiShhYK7b/Qzvx8FXqfhXKRknup8/yZicww==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.21.1.tgz",
+      "integrity": "sha512-+9qyKJS+Ab3BWqrWnFU5CSgEDGtoGJpe19TzpymSXDP0aSAM6lnkZpCvT3EKi/Y8Bmw9xRXJZwemtxQK2y4SSQ==",
       "dev": true,
       "requires": {
         "rdfa-streaming-parser": "^1.3.0"
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-links-next": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.19.2.tgz",
-      "integrity": "sha512-VhtNZmQMwphmEukNOC+RyNHY0DXpC7pqRQ7wNFC310y1emRUuvHCuA2fMyKkbBJe1Hm5tOt60inqAudYMz/eew==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.21.1.tgz",
+      "integrity": "sha512-x6q1vQ45egXGjX4T4RKFf6A35YNDqMdGIBdTi4LAocKqWnr1Nus2qcVP2oHKXQEDssZHYilq348J98B1Gyz1WA==",
+      "dev": true
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-1.21.1.tgz",
+      "integrity": "sha512-6h/9Dm/zBRqoLBZcZtV/x0dT3+goC9fIDJHqyzOgVg7Xf9iQsy2yEVfUNkqIWUK9Rh4dWglDfmdLihoZ7GKfMw==",
       "dev": true
     },
     "@comunica/actor-rdf-resolve-hypermedia-none": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.19.2.tgz",
-      "integrity": "sha512-Apur7/rfUdTn/O91ojGP2F4ZOwGzyHhv1rvg2AFbWUDsRIWu51AGur4/FVytRygR2QY14ZQf5DJu3gwRjeH5SA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.21.1.tgz",
+      "integrity": "sha512-Bm367n52hT2Tl0aGPL7Nao3Vb+SRfOQ0WVXyYRiIYgmgQ8RHuFiyDfj//o0GOmeu2dU6LxvfLK9KJdzvaBSXVw==",
       "dev": true,
       "requires": {
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.19.2",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.21.1",
         "@types/rdf-js": "*",
-        "rdf-store-stream": "^1.0.1"
+        "rdf-store-stream": "^1.2.0"
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-qpf": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.19.2.tgz",
-      "integrity": "sha512-FTPmc3UNcq70a1CJyre5XzyhausfnvWGeAEtnfi+ML7GD+xFZ0MM/lHEqdMHGakX1d7M3F9+muLetaS/zz+0HA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.21.1.tgz",
+      "integrity": "sha512-zgXqBeP8mlSIZEYLZuMVkfE88S67zmrnhtNfQ7iO8wuzgWboeeMhITMZy95/Fh9zKcIV1PSFuSH/BsDOXARHNg==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-dereference": "^1.19.2",
+        "@comunica/bus-rdf-dereference": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "rdf-data-factory": "^1.0.3",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2"
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-sparql": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.19.2.tgz",
-      "integrity": "sha512-jXpEiZU6Fc2/qHHEhpRwbIeU4sAPGQuP7fzlLvdmatbk78iI6l+G/u32R3tl0Vi/qETxi5Hhnr37v30msdqWXg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.21.2.tgz",
+      "integrity": "sha512-q6S9RDxzr00RViBrZ1wUHfzFjkXcHFWfRXbVI0bG2MR/oN9SVySLgSozte9KFjCWiuFc25jsntyB1dfXiH/i6Q==",
       "dev": true,
       "requires": {
-        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.19.2",
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
+        "fetch-sparql-endpoint": "^2.0.0",
         "rdf-data-factory": "^1.0.3",
         "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.19.2.tgz",
-      "integrity": "sha512-7txxy/D2//uMBQh204Oqfe3YfS2U9r+ftHvHWT+uVi+M4DX5kx7gO5LrhSl4KjqkjMUj9XicU2ZUWQbXsjkkJA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.21.1.tgz",
+      "integrity": "sha512-Leo6a8wIJ/zIxauRmzdz3bdKpW4tgSJb6QRle9/wP2FgNkimhh+Pt08f7ot2E/49ewgmwHyiv0ha5CQOwRxtqg==",
       "dev": true,
       "requires": {
-        "@comunica/data-factory": "^1.17.0",
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/data-factory": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "rdf-data-factory": "^1.0.3",
         "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.19.2.tgz",
-      "integrity": "sha512-RI5LYX18R74QQYPIeMyeXXlvrIzLFGPSFr6JCvuNDXlYsiq9ilL/5AePv1TsuLIgyxixK2N4KzAyZ0hO1maAdQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.21.1.tgz",
+      "integrity": "sha512-v8t+QW8mBrisLU2DErhyGo4DKrmLOKUjls2A1THYNSP8d1k1uKg3UDb9CXwezpfk+O4Q/wqtMzxOomJjxlgOaw==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-metadata": "^1.19.2",
-        "@comunica/bus-rdf-metadata-extract": "^1.19.2",
-        "@comunica/utils-datasource": "^1.19.2",
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.21.1",
+        "@comunica/bus-rdf-metadata": "^1.21.1",
+        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@comunica/utils-datasource": "^1.21.1",
         "@types/lru-cache": "^5.1.0",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "lru-cache": "^6.0.0",
         "rdf-data-factory": "^1.0.3",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.19.2.tgz",
-      "integrity": "sha512-+kTCV2So+GUoRxdSsYjuks2i2HjsfjXlzCKK0uYRGLXLmqUozf0zHh1ZfIZqdxDAFMwYiaTgPw2P9+MjICBYUw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.21.1.tgz",
+      "integrity": "sha512-bb8v9tUlgL4MhfGhDK7wHnrayF6oogRl4aby3gcWhgrzkGwmQzdTcldtZtdaoVBH5j30WE0dH36aHPxMkRha1w==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3"
-      }
-    },
-    "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.19.2.tgz",
-      "integrity": "sha512-XuNdqnDp2PegpZg6/9gs3V9XXmouQWTiD5yLBdFs55y+hUs+Y8ditaVXjqxfi7nCZhb+seqKupeWbDPQgOLpeg==",
-      "dev": true,
-      "requires": {
-        "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.4.0",
-        "sparqljson-parse": "^1.6.0"
+        "asynciterator": "^3.1.0"
       }
     },
     "@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.19.2.tgz",
-      "integrity": "sha512-JHrJcT6TeyUbs4JniOioTK8fNcvWCFbIvuAQnOKJQySVn4Y+spflui7eopp0xlTVzAqXQ1RXwhfO+pM9HIaM4g==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.21.1.tgz",
+      "integrity": "sha512-qQhLt00drQMJRlOkuPOjhPdgDQtezRW53LQ5cGa3otnFU1t7e6l9+PnKjjniXGaXLlxBLJV7tdkcDkqVL0XRww==",
       "dev": true,
       "requires": {
         "jsonld-streaming-serializer": "^1.2.0"
       }
     },
     "@comunica/actor-rdf-serialize-n3": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.19.2.tgz",
-      "integrity": "sha512-ZEsh1OVAUNbpUdybEqnc0eWQvQG8XekVkWhExIfOsRNIz3wm/echO62pXJqc5vILTP1d+dk5I0KkgibhPKQMMA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.21.1.tgz",
+      "integrity": "sha512-NGiczuyG9rNiY3F3cs8U1kT8EWWGxz50rmtWBnsMgHPNfXHk9Aztc1rWS8SEHTSK/PH0NK/fRe4p65Iq4TDfCA==",
       "dev": true,
       "requires": {
         "@types/n3": "^1.4.4",
@@ -1533,390 +1679,494 @@
         "rdf-string": "^1.5.0"
       }
     },
+    "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-1.21.1.tgz",
+      "integrity": "sha512-lLYMWc6hShnOFkIfbwW14t9Z9Zqb0hZJBN5trZt/98F39N+QNS5lE0rDeRhXUtXvp2NKrVvXPn/6q67V4Zb68w==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.5"
+      }
+    },
+    "@comunica/actor-rdf-update-quads-hypermedia": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-1.21.1.tgz",
+      "integrity": "sha512-NAKEPf6Gog83/biNo5U2p1KFkb0yzodQCZaUGWGjJIkbB2EEUYJyWBUBCnW5FX70/uXcv/AhhdTA8jAGwVo+5g==",
+      "dev": true,
+      "requires": {
+        "@comunica/bus-rdf-dereference": "^1.21.1",
+        "@comunica/bus-rdf-metadata": "^1.21.1",
+        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
+        "@comunica/bus-rdf-update-hypermedia": "^1.21.1",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "@comunica/actor-rdf-update-quads-rdfjs-store": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-1.21.1.tgz",
+      "integrity": "sha512-OexfNx+0eIs201/Ig56IjiN5HNsp3lX1YC7bMwDHPNFWmRhW8XrTnbHED3vPe81Qx/9FgahJHf7fRwHlgUlioQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-data-factory": "^1.0.4",
+        "rdf-string": "^1.5.0"
+      }
+    },
     "@comunica/actor-sparql-parse-algebra": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.19.2.tgz",
-      "integrity": "sha512-P0LT4AtTYUjlmMh+mPAjhDs4rdebmbiExJtKoyVnVB1zeb4jhz/PlcxxcKslk1SWCEYYggcgTky5IM4XexZ/yQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.21.1.tgz",
+      "integrity": "sha512-sZVyIfGiMHEG3CaPFYIO9V27sjEgW0nLx95ASSexY+5qYlwEog97CJxP/gblm/fDIsNRQfQgnhQUzyAW7AuYCw==",
       "dev": true,
       "requires": {
         "@types/sparqljs": "^3.0.0",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0",
-        "sparqljs": "^3.1.1"
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqljs": "^3.4.1"
       }
     },
     "@comunica/actor-sparql-parse-graphql": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.19.2.tgz",
-      "integrity": "sha512-F8VnaH9fkLf2bRNfgsRfuvGLr6WBEgDrQ7WhYr17eYKDlEcb3S0fm8iCgjdde7j6jk7K+fGn5MoiorM4Koqpzg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.21.1.tgz",
+      "integrity": "sha512-qC2NAjK+ff3CHqsnsiiW8LZJ9V5004wI3gRoIz0stwljGvk3i/gmxs2sWucbi/IpgqFK4eaxQcGc3XTE4E4qig==",
       "dev": true,
       "requires": {
         "graphql-to-sparql": "^2.2.0"
       }
     },
     "@comunica/actor-sparql-serialize-json": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.19.2.tgz",
-      "integrity": "sha512-YQ/Zd1Z+2am3uG42M/R65nag9KajJREyhr4Nq4ABIQqt1f6JDHV7ccyxo1mU8S+sRKsakjB3uUmRb+8A790ceA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.21.1.tgz",
+      "integrity": "sha512-NuPJzuKVdq435Al5hLnwA3reZXyiYohbM2WTgeffyB45VFNGsx7OBKkMDlprwpbH/XD4PUdQjrwDqwBxzRCXbw==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
         "rdf-string": "^1.5.0"
       }
     },
     "@comunica/actor-sparql-serialize-rdf": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.19.2.tgz",
-      "integrity": "sha512-eTWm77j1j0gTacajE/W51lT4CKL+x6rRvfTkRnrKNkyCuVZd/j8gIT1f82Yf6K4TqxO6LJ6VwFFXF3sxx6nVmQ==",
-      "dev": true
-    },
-    "@comunica/actor-sparql-serialize-simple": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.19.2.tgz",
-      "integrity": "sha512-OwCWS25PxcskYd0V0GMVJEXb7GQzGZufN2fBYSpodtl98rTiCbC3c7sMShoqCm79GkuHhNLOjT6hLcJCFettAQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.21.1.tgz",
+      "integrity": "sha512-5CIA0LGO0VtCT5DMzOIVSVS1y2D8INkSrsOzOyP1my0fBYK7s0c9O5khaZYI7sBOgjOhAeHz6yECjz7EWmdATw==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1"
+      }
+    },
+    "@comunica/actor-sparql-serialize-simple": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.21.1.tgz",
+      "integrity": "sha512-2ud0Uc3JlUM0SgRP1BXXGYwFBAmuuJhx8UBIA1K0VmJ7oik8kYaPLROcOFbT6LiamQ6tDoGPgqnZ/08xvuuF0Q==",
+      "dev": true,
+      "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-csv": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.19.2.tgz",
-      "integrity": "sha512-jYlWfAghrApzDF2YUR3gkLuBQ4qMeDUZDKnEimIFDGfN1IgQUrrkyeui6YEXEbDwd3tu171QjNsEr/5DZFmr/A==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.21.1.tgz",
+      "integrity": "sha512-Pki5Wi6DI7o6d44xW7jXyq5LfzLUDBNyObuvR8V9LuL5uAcJp2kjJyPkzuv5YNQYG+uFHQT6Xno8bXHSuD+vHA==",
       "dev": true,
       "requires": {
-        "@comunica/bus-query-operation": "^1.19.2",
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-json": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.19.2.tgz",
-      "integrity": "sha512-va/hIXJnCPnex+bq8/MABQrM4TWB1FKGhUlrSKdaOpmNgMAbKr6ylPbO1XOtNcqLfwGK2phVvPbPipGjTJEllw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.21.1.tgz",
+      "integrity": "sha512-vYvufYI/6j6KZB+J9LE7P7p6DtCtRAI0CBu47YJ4R9AVFvaHUY+OBuznTqEUvYLFGjsfnr/tylKrrPHvGQIPZA==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-tsv": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.19.2.tgz",
-      "integrity": "sha512-J8AgOeWUGSi1xWVjz/pd5MPkZlbBoOVhWShEob4MuzOb8ZvOd1K3hCi8IA2ZGH2FE4TMJcryB5RK7PAEal42uw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.21.1.tgz",
+      "integrity": "sha512-AhJH8q2lS+wdha6hRYOSYE0pk9h2tLuh4nAuqO+oOMv/eKOtEJkkKOtt+d3mez7Q1G39vm9WrqEtodPvLWsSkg==",
       "dev": true,
       "requires": {
-        "@comunica/bus-query-operation": "^1.19.2",
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
         "rdf-string-ttl": "^1.1.0"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-xml": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.19.2.tgz",
-      "integrity": "sha512-DDpmjaHX+BTkLmXlaNp++U3heIF08tV36jVaLqaV2OXTlg2sdMBL67Lupd2ZRv/lYSAnwwiTr+WFimMcnptQpQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.21.1.tgz",
+      "integrity": "sha512-Xyqo8qF3F7SkLGHmXeHjDF5JqBB5EmpK35JkIHqmVmu2aTS+LfF8d+pMGoWQQn4FRl+IGG4O+sp9B4wXGAW6sw==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
         "@types/xml": "^1.0.2",
         "xml": "^1.0.1"
       }
     },
     "@comunica/actor-sparql-serialize-stats": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.19.2.tgz",
-      "integrity": "sha512-NkrLai5Q8UEJCNYMK5/W5DGpVoSdIm8bBYrIY1ONfuS6keizROAE0Fz86yzmAxPSlVKZOoqCjCCaLemO7cAsIg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.21.1.tgz",
+      "integrity": "sha512-vuDzN+8ZWTcSK9fz5F4s0uSEclMTZtKzCBTwdvxDPAQ2zFkbsCPQzZ8Cmn0MxGxUk4sKR7rjY1ELUsD/ZXqprw==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-table": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.19.2.tgz",
-      "integrity": "sha512-gcMAXVmuatSc5COY7A4bIS/kxry4EvzIhdJ6upf5p0Z+TL65nWSsFPUvr2erRBWjl3rlDPFHfBmn2vTtggumFA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.21.1.tgz",
+      "integrity": "sha512-9iUliyqhXZct+CikD/7KSv/rujeE2odkpNMrJUflTZqtHeb0c90jWxHlgYmfV3u8lQi44F4G5tk33gX3m8O2ag==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
         "rdf-terms": "^1.6.2"
       }
     },
     "@comunica/actor-sparql-serialize-tree": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.19.2.tgz",
-      "integrity": "sha512-PyYBxruXKVVVRTdkU1fGhddaT6FXLtBY0rAPbd/ve0V4Ddte6Ey8ZXlUlsuoo/xAR6N6e6yV9bfc+QZ9rdnpvA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.21.1.tgz",
+      "integrity": "sha512-628vwFD/bBcheUyrhLm8LajZV8MjfbTPvVnBuxU6iRkKDTZnqv0pDGltEjGImQuc+3E/2KLk9JuMZquDWClPgQ==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
         "sparqljson-to-tree": "^2.0.0"
       }
     },
     "@comunica/bus-context-preprocess": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.19.2.tgz",
-      "integrity": "sha512-CNYFubbQeCnhf2ZsIqLC/0u3zF0tJwqhvMc3rF9qnHw3SWtttGsBQpYtaOZR3uR7FSVJvJqKV65qLedumQdOog==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.21.1.tgz",
+      "integrity": "sha512-fJAKiNScSPB82aNjmvJPNAgBdCOJ4Y1oe26brHvyvHgcIyq00sqNxlJXa3C4W1tS/LkyT+lXfG7pheYC8cZzdg==",
       "dev": true
     },
     "@comunica/bus-http": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.19.2.tgz",
-      "integrity": "sha512-dRvN7k/ZjHly+Dr+baanvHPP3MjZINE6j7Zp8TAvV2wq6KQaJhUWRSfAVbzw3AkSWy2txtC3zXUpTYGJYYiV3Q==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.21.1.tgz",
+      "integrity": "sha512-M6gi128ME+7uSnLPz4Bx3jgXhIb5/O7tODVHAtw9gt0z/9AAuYfmW9jqmcZ5Uwv3CCvJSvEc/m+dooCv35dTsA==",
       "dev": true,
       "requires": {
+        "@comunica/context-entries": "^1.21.1",
         "is-stream": "^2.0.0",
         "web-streams-node": "^0.4.0"
       }
     },
     "@comunica/bus-http-invalidate": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.19.2.tgz",
-      "integrity": "sha512-eekin3KzdJeTxwsaX3XJ31eoNfc13mN4KXSpn5Unuu5lo8VmM8+CQauA4sJqkUwjbSlFqny60QZlUOPYZ/wOeA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.21.1.tgz",
+      "integrity": "sha512-+Kb18K/ukOm8zHSXkYIGXh4cmdyEYsF/aTyVRsSyB5FHijuZCQ5p4PEgYjsurWSinfC76WOtONf3qLmkDAXErg==",
       "dev": true
     },
     "@comunica/bus-init": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.19.2.tgz",
-      "integrity": "sha512-SVIcKPSrPlHxrndsKX650ijrOPMyBdZZkDe/mLXUKNq7cSerdQZtP6w95u7/fnBwjwXOAMjPiyP3L07rD6KAcA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.21.1.tgz",
+      "integrity": "sha512-h8Gp/iJiyY8mbqhrbfLySwTXasjxmCX6kpM9RyXWqCBJzdx8Bfq6F/nYg2N+zpEJgyrn5zLdNgbBkcDetdeAmA==",
       "dev": true
     },
     "@comunica/bus-optimize-query-operation": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.19.2.tgz",
-      "integrity": "sha512-Y5CevNB+NYO+PHwTOOWCDYh9YF53BWZi0OFsX26HdqxnqODYSt56pYFMDozeb+OBWTX0NN68CH4QUCjvNSPJbg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.21.1.tgz",
+      "integrity": "sha512-LTWYILQC//EYhWfokp/BluI0ND++31kQNjWRlXrnVHsriieptMx6bEFsWU3qbc8LapLvBj9VVOGfHzXZieYghg==",
       "dev": true,
       "requires": {
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/bus-query-operation": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.19.2.tgz",
-      "integrity": "sha512-s9vzwYcgaRuOGWUA1WDGcOO+j7pjB2Vf1bCOUR/4Xdoz795ev415q3qtSqQISvNVwj5LM4pk0mcXDHsISRDn2Q==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.21.1.tgz",
+      "integrity": "sha512-sofM518TRNPZzLlL08cIoF5cGR3PFSXykgRMp4P+eCtsbrgnoSXx3sBOimO96VUV3BSZsWAJzXxAOeaRPM8XOQ==",
       "dev": true,
       "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/data-factory": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
+        "asynciterator": "^3.1.0",
         "immutable": "^3.8.2",
         "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^2.4.0"
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/bus-rdf-dereference": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.19.2.tgz",
-      "integrity": "sha512-vK73nWJh1xF5Br1NFNX0Lx8nF6NDwKwgMzxqIxOj/gOxUJgTFOaWm7/brYc38ITSrDfYOAmlL4p2bGMNkdfm2A==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.21.1.tgz",
+      "integrity": "sha512-gejQdUmWCtXzlrSIVwVBuTtijLncO88hpqZjqkNo+WKTilCT9GdXSqRw137GX6ZPsBXKf/Pztupid3oUPG+2xg==",
       "dev": true,
       "requires": {
+        "@comunica/context-entries": "^1.21.1",
         "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-dereference-paged": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.19.2.tgz",
-      "integrity": "sha512-wn/bLMxDeWVyuT9zbrpFPpO0DtWVSrTB4R0j+DLOM1mk2PiLqW1LaxCQoUQl6+yxf9kwM7DOnNDgCLb/PhKmlw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.21.1.tgz",
+      "integrity": "sha512-E0SQt34A9y9ffa01+NnyXNPazY3ckmr/qmKsWbfNWnVMtgVKqRb3GnydOktYL5jLvNcAaEN1w9AnRxqM6VtoFw==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3"
+        "asynciterator": "^3.1.0"
       }
     },
     "@comunica/bus-rdf-join": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.19.2.tgz",
-      "integrity": "sha512-2/W25J2UmCTj9J3Dy46DRZRVxyeyDDRt4LmNevdSyYSsp8RhhXHTWkqzhJQekgRK/AALofy3b6xWJTBpbfX7cQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.21.1.tgz",
+      "integrity": "sha512-O2rBiE2TiEWO1H04b3GQcSg46zV8gpeh6+Fx8Swr+XDV5W4aMvGxl+OsblstAY0cFCb1zNBokozAh6eYTLh3Wg==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3"
+        "asynciterator": "^3.1.0"
       }
     },
     "@comunica/bus-rdf-metadata": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.19.2.tgz",
-      "integrity": "sha512-4HlBnOMy6VgCCsVA4yNAGavE3fxEHJ3AUxMUQSfh3Si38Ww1fUp1BVo39vLMb/rbxfVyGMDWqfB31wHYXFjnHA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.21.1.tgz",
+      "integrity": "sha512-THCujnE/utBRzc6uJAuB9TKm2PIVphgr1UyWufLrcVG6UBIFYpsff67aZF35brBE85rnpGbyHxwDGh521lg7qw==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-metadata-extract": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.19.2.tgz",
-      "integrity": "sha512-yo8HR4oidch0x0teAtnyKE+NDE07l8GiiU2anmgHS+fkZ8NlBBpbwT780kjpeTfHm2XuJzDCiYJR7Lhnbj8HZQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.21.1.tgz",
+      "integrity": "sha512-Q1T54qlM3Vpev6H4Y/BuMpfz+Qi6/UcDeRo/eySovtCpJ2bWi8w/+UNdeGAZhYL9InqO9qJ2PUn+TiQ/sGIojg==",
       "dev": true,
       "requires": {
+        "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
         "graphql-ld": "^1.2.0",
-        "rdf-store-stream": "^1.0.1",
-        "sparqlalgebrajs": "^2.4.0",
+        "rdf-store-stream": "^1.2.0",
+        "sparqlalgebrajs": "^2.5.5",
         "stream-to-string": "^1.2.0"
       }
     },
     "@comunica/bus-rdf-parse": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.19.2.tgz",
-      "integrity": "sha512-tXTAWFHdmrZXmze9tWOyih0dgxaCL1qusJHIdtLW3Krt9BZhhUjPVckoHTFB+LSexmOEDHF91+WrkTwBxIDGpg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.21.1.tgz",
+      "integrity": "sha512-JQD9Cgml/W+PCSEX3WulwxiQOdULFxAFDipLk69/J9WZxOj6emufxStM8M9R+pavbLaLYRcBQWgO0KLhEn/Rnw==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.19.2",
+        "@comunica/actor-abstract-mediatyped": "^1.21.1",
         "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-parse-html": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.19.2.tgz",
-      "integrity": "sha512-TdhTZ7/UKQl75kndpHlIWHPQVxuRg2wbViEhQgvZBu7nyWR0F39Sh4A9iGhmdiwgZkQ8MdGIjQEdwbcSPtxN4w==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.21.1.tgz",
+      "integrity": "sha512-DJDFB8lxTJ1Pt+AhjOqe9hvj2nKtC23fJfEihU7DYIbz67O5pXAFgFtp9gn3gefoGB7T/CKoB8y8DcZy8N5u0A==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.19.2.tgz",
-      "integrity": "sha512-BqQDrIIdIExA3pRmmxRrWc87XUpbbayL1OZf/eiXFa3qWgqmtUuhRtzom3BYO2Oy59yVcK7wZm/hMXQQX1aaAA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.21.1.tgz",
+      "integrity": "sha512-eXjeGv86pw4SQAIEVtinwxCxYAwnaBaXqMxHMlplfBLcr2S2g0X5uxWbH9jQPpegvpQF8mX6y9VuslPC0ZzGMg==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3"
+        "asynciterator": "^3.1.0"
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia-links": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.19.2.tgz",
-      "integrity": "sha512-mW2iarewZz3nuFagbvN04JDj9MHrP7QCT9h0B8gBot7fUibZtn2n6yJPK7LOJHaLditQ+8zOMoAH2SDwjakq/Q==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.21.1.tgz",
+      "integrity": "sha512-+g1s+Csz019Ma7YscdYwYCaVvodKggjPpI4yaM60dd/FQZIY9bMRlXr35k9b4HiIvQK4BEAUX/y9bkaSdbSJ5A==",
+      "dev": true
+    },
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-1.21.1.tgz",
+      "integrity": "sha512-GAn27HnCw2pQW8974jjEKlFfi6i89QAYIUqw5w3VlYc8lbyaSDO4G+7rKt1mgIA/FHtxwXNgeRWUkxEdMZd3tA==",
       "dev": true
     },
     "@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.19.2.tgz",
-      "integrity": "sha512-x2QeGGK6ktG/UJCx5nuJqLjxl1RizSdTS6biEzcO4ZtXZ+S2K03PCFKd1YgufLPWXtajr32WnKAvD//wpTO6mg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.21.1.tgz",
+      "integrity": "sha512-3gxbhHBAC62GqVZx567+yee1Y1gpjfLQ59dHC04cRsYPRfWg+5pYAizFFlP+R1dR8StIcR89WRzZpmmZRrkVhg==",
       "dev": true,
       "requires": {
+        "@comunica/context-entries": "^1.21.1",
         "@types/rdf-js": "*",
-        "asynciterator": "^3.0.3",
-        "sparqlalgebrajs": "^2.4.0"
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/bus-rdf-serialize": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.19.2.tgz",
-      "integrity": "sha512-HrtI/6CZ4Oi2L9zvGJqFH3DABAHtW9EmhqLGispLoGSwPLUO79hPOnyZw9TjTaEYHnO5uI2tjacXQm1fd7BHNQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.21.1.tgz",
+      "integrity": "sha512-W0UPwMQbsINBHC1/JKFZLAyIXHW/gXhQFF/YqSvAvK9N38BkhQiBIz5+pZli+NgWz9g7nNUq5A2Jbg5Xmldj8w==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.19.2",
+        "@comunica/actor-abstract-mediatyped": "^1.21.1",
         "@types/rdf-js": "*"
       }
     },
-    "@comunica/bus-sparql-parse": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.19.2.tgz",
-      "integrity": "sha512-rFlVGxX2ThYGEdmTC9ZkV6rtxUF41ShuyrK89/n7lyRzJH8oBbXsjUwymG5oEEsYc3PWLTVirCQCnZvbT8VCeg==",
+    "@comunica/bus-rdf-update-hypermedia": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-1.21.1.tgz",
+      "integrity": "sha512-XnL2muy5bj3ldFa0IUjrytkFvCB6KMfuCC1QnP4ezh+atykColkIab1MbR7M2stsmeRiSMbEtSaE/RS7i5r8CQ==",
       "dev": true,
       "requires": {
-        "sparqlalgebrajs": "^2.4.0"
+        "@comunica/bus-rdf-update-quads": "^1.21.1"
+      }
+    },
+    "@comunica/bus-rdf-update-quads": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-1.21.1.tgz",
+      "integrity": "sha512-Ue/n+BimHe97mKPMpIDu26mD2SYse2+NvbpoqTfi7wIojcwmQwRiZoOxXupXOmIbWzmcCfNAIH2+1ZMoUCz3QQ==",
+      "dev": true,
+      "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0"
+      }
+    },
+    "@comunica/bus-sparql-parse": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.21.1.tgz",
+      "integrity": "sha512-vSY4O5CD7wxRWY78ZO+ZRSBYBOnxAcz9meqe58Y31B4jdPg7YggZLQ+095t9P4BZqRVeIrseCddDiyEpG1iJDw==",
+      "dev": true,
+      "requires": {
+        "sparqlalgebrajs": "^2.5.5"
       }
     },
     "@comunica/bus-sparql-serialize": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.19.2.tgz",
-      "integrity": "sha512-104o/7ya4+raft6Ofw/CXGa2LzJfZMLELyK0LOqXvDY1/VBT5KWwtZbsbRaWB90oX0hbvJAxun8f37XP00hCmQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.21.1.tgz",
+      "integrity": "sha512-qxKe1idPxVsfcdq8EPTDNB2P54fnXe+3vvaWeS1uG5yY1LMh39hSRGR/bz8BSsO1CZBytNvNjEaUnfFrWQcYuA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.19.2"
+        "@comunica/actor-abstract-mediatyped": "^1.21.1",
+        "@comunica/types": "^1.21.1"
       }
     },
+    "@comunica/context-entries": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-1.21.1.tgz",
+      "integrity": "sha512-7wBb+J+YLg4hcRQLFeP6/2b/xyK+lnQlc71OSjVMinQx1OO6tsjqlqHvQ6py56uVFs3cYduASgFuHTRVuoe1xA==",
+      "dev": true
+    },
     "@comunica/core": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.19.2.tgz",
-      "integrity": "sha512-BmUZiuCbR2T/sFlmKW6mRRBIH7hef2irNIB2nA3dDbRj5MyHVOEDDh0cJdbgMtWaHyM4m2Bw8gk8c63fQsfMPA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.21.1.tgz",
+      "integrity": "sha512-5lY/HkyOCorY2CtxQiKUKEOcUGjIKf/YG/txJrz84SKuy+zC91zq1Zt8qWfzNihCcWrgfmk0oZuvjbYvZGK4EA==",
       "dev": true,
       "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/types": "^1.21.1",
         "immutable": "^3.8.2"
       }
     },
     "@comunica/data-factory": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-1.17.0.tgz",
-      "integrity": "sha512-AjU4kpIWq5Rx7MN/uGlmrAHCvPri2I6GMc+zUL7URMlj8veOk1R9w7ol5Z3mtpB65NhYQJtB4D9riff30b6/lw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-1.21.1.tgz",
+      "integrity": "sha512-bMAyc0YvBFR7n1olpk1kDLh5SYrVNnInPq9Ceh/FJiEwlvFOJBTGB949HHIXmRWAjuUDwSSFQRX74M9kURCHzQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/logger-pretty": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.19.2.tgz",
-      "integrity": "sha512-Vd206zfJGkYePIfa/InY83VVd5VPx/tfwdq7brAPQjL668W8UPsfVBHwvib1/unTB1cDvp0Xv76MigjfwMZ1XA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.21.1.tgz",
+      "integrity": "sha512-69aolnWF0fGSn3D+aniLuglbTW1/ZuG9WkWEzSfdzAHrdAlj7GjN+mT50C3C16rBUGZIMLt8gl7thfqpIgN6hQ==",
       "dev": true
     },
     "@comunica/logger-void": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.19.2.tgz",
-      "integrity": "sha512-FK8C26HaMz4XSIT3iiP6SYb5oNNBR2+OPc3Fq6yCBfx/Nzyw6pK69A9DszxKNZ7R4BACSZRYJqbhvqyxEBK2CA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.21.1.tgz",
+      "integrity": "sha512-uw5rc7GmMNygcV8xkQEKKpLI36AfW4WSXKUbOODHXhfmq26LpYmKmZzwYTqYoUzeokHTljD5rEOILfCBDtb+1A==",
       "dev": true
     },
     "@comunica/mediator-all": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.19.2.tgz",
-      "integrity": "sha512-NgVXh9aRsFaurXh5BElLYYn1R+90q4itq+DcJbHKJsC87ysuLUazVKe1vNLohvJbdfst0Ga1WUH7Q9RpB75Uhw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.21.1.tgz",
+      "integrity": "sha512-QfY4LCVeZa/UTWNRTbXi9KsK1Vru//eYcKpqYqqKOnoD1hltfFFrxHF8ekO9yB++Z487IRhk8Z8SFwU4yjYP9g==",
       "dev": true
     },
     "@comunica/mediator-combine-pipeline": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.19.2.tgz",
-      "integrity": "sha512-j9YXmKJH350lBy2vkjYC2ouikkPXDllEdr0xUl3uVUcz56Gr0Jn/tUUl/kGteLHSb+wMzmBvpbbedBoVpfhLbQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.21.1.tgz",
+      "integrity": "sha512-H9b5ItQ216OO05fzwNOhueuaR5v2EeYcJCZFBwDzsqngVG2mHxclm53568ALZqGlLOTxQccCOEJEUj7Z21swtQ==",
       "dev": true
     },
     "@comunica/mediator-combine-union": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.19.2.tgz",
-      "integrity": "sha512-UHC0yS8rVbSqyg8ndyKSxd8lLnQYiMzyYwbTQyMSSOJCc7WCYPXME1IMlNlsO7c0BC7hxXLZPkeIGLAYh5/CEg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.21.1.tgz",
+      "integrity": "sha512-wp2lbViVOOeNKTBRD+6sze7TKVX71T2RD324/1Syb8vOpwT3mtaDNJYFg0Mrwer/Xs54d7nA7JGZA2wC2HaXow==",
       "dev": true
     },
     "@comunica/mediator-number": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.19.2.tgz",
-      "integrity": "sha512-VMT2yM++DxQUhR7IJp1yS1rOXzIyXY3si4SQQMzAKIUGwgVWvW/SnB9Ds3JLXnNl4Ptb7Y+kRQZAffHZzBw41w==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.21.1.tgz",
+      "integrity": "sha512-OeuGx0R/mWI1uMMXM2V1vcR8J1DPhYXPR+Ncg4/qKHl7tSCQH1tlCgZu0+fovY2Qmc14f1tmw5YgnsE8lsikSQ==",
       "dev": true
     },
     "@comunica/mediator-race": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.19.2.tgz",
-      "integrity": "sha512-F+PxeAWTrMEW0s48oaV5h3YrywoO3vPqCgSKyDfRx2YtjJX3SjJduGVNsKKCK4oWNG/NINOg3eUaTG8p4JMbWQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.21.1.tgz",
+      "integrity": "sha512-SgdtF1JmqDyhZJsAOiVMPuV1qgdXqv/hbsFCxcmDQ+8q1ObmQ+0DZvdUe5Ymf2IyFaevsOHHG7hF5hJbLZmdmQ==",
       "dev": true
     },
     "@comunica/mediatortype-iterations": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-iterations/-/mediatortype-iterations-1.19.2.tgz",
-      "integrity": "sha512-FegoAy36aa3dceqSo747YmDOgUdkLVYb5QvW8I0+uBNkfUcYJAzvne36ERVIcIPrhNkkS5KFYR+P4Nw4mHcHkA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-iterations/-/mediatortype-iterations-1.21.1.tgz",
+      "integrity": "sha512-UmPlJS4ryt4QoYKlsYugfTsTAioWeiX3OPye3yKTjVW31V2iq9CCaWALFm2engutjf24R3lU73JRcINr9K6Q3g==",
       "dev": true
     },
     "@comunica/runner": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.19.2.tgz",
-      "integrity": "sha512-BfwVSI1M3/cPxC/006KyR1TDnmuxGY+lENZRAs3BWc1RaCmkcU/V9+yrxWmUHYfSZgVZ4sQovkC/BTwLiMUBaw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.21.1.tgz",
+      "integrity": "sha512-yFeHvFLGHTYXlROK6xKoWLnW0Wx0jL+NRzvB3izIXc+p34bOuua8sjmGFQzW0OU7/04S0xM8BUTG2n33s26yUw==",
       "dev": true,
       "requires": {
-        "componentsjs": "^4.0.3"
+        "componentsjs": "^4.0.6"
       }
     },
     "@comunica/runner-cli": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.19.2.tgz",
-      "integrity": "sha512-glBNAUURfwmD1/xTwJNfw3vBoBp9Lzagqe/gcpzGhj+62xZ5KBfoE9fMu9gFfc10uXHHuvoXTfIISfxQbWd0SA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.21.1.tgz",
+      "integrity": "sha512-T25yhU+2WJrP0xcYYpKiCPFSedy5Ml8/3geuPgU/FZZijma2jb9+PA1R9n9Mayr+Eqj37G6blcjgZ2cIVpo4aA==",
       "dev": true,
       "requires": {
-        "@comunica/runner": "^1.19.2"
+        "@comunica/runner": "^1.21.1"
+      }
+    },
+    "@comunica/types": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-1.21.1.tgz",
+      "integrity": "sha512-Sdp8m9yvKbcCSx31L4nLe0tORCRc1TvUXSgpIUVGBXunqZpoWAhxcn2PZn7//xb6xnYUjHqrQZhYQbMdDIqONQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "immutable": "^3.8.2",
+        "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/utils-datasource": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.19.2.tgz",
-      "integrity": "sha512-XZ/qg5cq/0N/ixqbV9dnYkGK/deELdHUSiWV6Mt6OuRqI1d2m0UEid5SFa1eaaHgjLFAbf01YH0TglVtiOKNfQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.21.1.tgz",
+      "integrity": "sha512-4xCOa0j7y972haYZWcNMfuHzOjyjOmM3dj6+wacW243P1VmsPv7xwb7sY4s+VcdmX6AcEEGM5wZ+3fm/mSgR6g==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
-        "asynciterator": "^3.0.3"
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/context-entries": "^1.21.1",
+        "asynciterator": "^3.1.0"
       }
     },
     "@dabh/diagnostics": {
@@ -1937,15 +2187,15 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
-      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+      "integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
         "espree": "^7.3.0",
-        "globals": "^12.1.0",
+        "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
@@ -1989,28 +2239,28 @@
       }
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
-      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.stat": "2.0.4",
+        "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
-      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
+      "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.scandir": "2.1.4",
+        "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
     },
@@ -2038,9 +2288,9 @@
       "integrity": "sha512-UfdK1MPnR6T7f3svzzYBfu3qBkkZ/KsPhcpc3JYhsUY4hbpwNF9wEQtD4Z+/mRqMTJrKg++YSxIxE0FBhY3RIw=="
     },
     "@open-wc/eslint-config": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-4.2.0.tgz",
-      "integrity": "sha512-+HyzbR2tJ+8KSbv/ytxMk5SIcO306ilVQtNchcN71SnHsNSE2dWnFOMy9cG2rYZ9zjx7RXgmEiS/2ta/RdMQ5A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-4.3.0.tgz",
+      "integrity": "sha512-kCxFWQ1AR4meTmWJGnK36LJYqDJeFGjlj6n4vLjAW3/c1VUyYQKL90vrNKy/OHS9kTjc9dcH5D64myAbNx6r1w==",
       "dev": true,
       "requires": {
         "eslint": "^7.6.0",
@@ -2073,9 +2323,9 @@
       }
     },
     "@open-wc/testing": {
-      "version": "2.5.32",
-      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-2.5.32.tgz",
-      "integrity": "sha512-vl8VwTG3CVLwLcd1mpts8D9xPptc6xPL/9AHEbQxX1IQsFBEiFQdARSp1+V/i7gK2+peXeotqrZ5NvoHxl/lLw==",
+      "version": "2.5.33",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-2.5.33.tgz",
+      "integrity": "sha512-+EJNs0i+VV4nE+BrG70l2DNGXOZTSrluruaaU06HUSk57ZlKa+kIxWmkLxCOLlbgnQgrPrQWxbs3lgB1tIx/YA==",
       "dev": true,
       "requires": {
         "@open-wc/chai-dom-equals": "^0.12.36",
@@ -2083,13 +2333,13 @@
         "@open-wc/testing-helpers": "^1.8.12",
         "@types/chai": "^4.2.11",
         "@types/chai-dom": "^0.0.9",
-        "@types/mocha": "^5.0.0",
+        "@types/mocha": "^5.2.7",
         "@types/sinon-chai": "^3.2.3",
         "chai": "^4.2.0",
         "chai-a11y-axe": "^1.3.1",
         "chai-dom": "^1.8.1",
         "mocha": "^6.2.2",
-        "sinon-chai": "^3.3.0"
+        "sinon-chai": "^3.5.0"
       }
     },
     "@open-wc/testing-helpers": {
@@ -2113,41 +2363,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-a11y-keys-behavior/-/iron-a11y-keys-behavior-3.0.1.tgz",
       "integrity": "sha512-lnrjKq3ysbBPT/74l0Fj0U9H9C35Tpw2C/tpJ8a+5g8Y3YJs1WSZYnEl1yOkw6sEyaxOq/1DkzH0+60gGu5/PQ==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-flex-layout": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
-      "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-icon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-icon/-/iron-icon-3.0.1.tgz",
-      "integrity": "sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==",
-      "requires": {
-        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
-        "@polymer/iron-meta": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-iconset-svg": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz",
-      "integrity": "sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==",
-      "requires": {
-        "@polymer/iron-meta": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-meta": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
-      "integrity": "sha512-pWguPugiLYmWFV9UWxLWzZ6gm4wBwQdDy4VULKwdHCqR7OP7u98h+XDdGZsSlDPv6qoryV/e3tGHlTIT0mbzJA==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -2178,10 +2393,19 @@
         "@webcomponents/shadycss": "^1.9.1"
       }
     },
+    "@rdfjs/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-YxVkH0XrCNG3MWeZxfg596GFe+oorTVusmNxRP6ZHTsGczZ8AGvG3UchRNkg3Fy4MyysI7vBAA5YZbESL+VmHQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@rollup/plugin-node-resolve": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.0.tgz",
-      "integrity": "sha512-qHjNIKYt5pCcn+5RUBQxK8krhRvf1HnyVgUCcFFcweDS7fhkOLZeYh0mhHK6Ery8/bb9tvN/ubPzmfF0qjDCTA==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz",
+      "integrity": "sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -2204,18 +2428,18 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
-      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
-      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -2258,9 +2482,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.15.tgz",
-      "integrity": "sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.19.tgz",
+      "integrity": "sha512-jRJgpRBuY+7izT7/WNXP/LsMO9YonsstuL+xuvycDyESpoDoIAsMd7suwpB4h9oEWB+ZlPTqJJ8EHomzNhwTPQ==",
       "dev": true
     },
     "@types/chai-dom": {
@@ -2334,9 +2558,9 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
-      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.12.tgz",
+      "integrity": "sha512-pTYas6FrP15B1Oa0bkN5tQMNqOcVXa9j4FTFtO8DWI9kppKib+6NJtfTOOLcwxuuYvcX2+dVG6et1SxW/Kc17Q==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -2346,9 +2570,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.18",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.18.tgz",
-      "integrity": "sha512-m4JTwx5RUBNZvky/JJ8swEJPKFd8si08pPF2PfizYjGZOKr/svUWPcoUmLow6MmPzhasphB7gSTINY67xn3JNA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.21.tgz",
+      "integrity": "sha512-gwCiEZqW6f7EoR8TTEfalyEhb1zA5jQJnRngr97+3pzMaO1RKoI1w2bw07TK72renMUVWcWS5mLI6rk1NqN0nA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -2393,9 +2617,9 @@
       }
     },
     "@types/istanbul-reports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-      "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
@@ -2414,9 +2638,9 @@
       "dev": true
     },
     "@types/koa": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.0.tgz",
-      "integrity": "sha512-hNs1Z2lX+R5sZroIy/WIGbPlH/719s/Nd5uIjSIAdHn9q+g7z6mxOnhwMjK1urE4/NUP0SOoYUOD4MnvD9FRNw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.3.tgz",
+      "integrity": "sha512-TaujBV+Dhe/FvmSMZJtCFBms+bqQacgUebk/M2C2tq8iGmHE/DDf4DcW2Hc7NqusVZmy5xzrWOjtdPKNP+fTfw==",
       "dev": true,
       "requires": {
         "@types/accepts": "*",
@@ -2463,19 +2687,19 @@
       "dev": true
     },
     "@types/n3": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.4.4.tgz",
-      "integrity": "sha512-xsWfwyDh0uAH0CXvwqe9vb2UEDafMjRez/pB7yZwbWpd9Olw2wdxaL32FtdHjmmFE6b9i+j249JfRyZnvWkoqg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.10.0.tgz",
+      "integrity": "sha512-PTr6D6IV3l+dG0Og6E2vHVyXNAyOjEPEz1si3htgo9bkgjIj+9HDS68cbXjAxH7P5bDzyL1Cu5yaHZwjKYtLAw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "@types/rdf-js": "*"
+        "rdf-js": "^4.0.2"
       }
     },
     "@types/node": {
-      "version": "14.14.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
+      "version": "15.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
+      "integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -2506,9 +2730,9 @@
       }
     },
     "@types/qs": {
-      "version": "6.9.5",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
-      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==",
       "dev": true
     },
     "@types/range-parser": {
@@ -2518,12 +2742,12 @@
       "dev": true
     },
     "@types/rdf-js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.1.tgz",
-      "integrity": "sha512-S+28+3RoFI+3arls7dS813gYnhb2HiyLX+gs00rgIvCzHU93DaYajhx4tyT+XEO8SjtzZw90OF4OVdYXBwbvkQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.2.tgz",
+      "integrity": "sha512-soR/+RMogGiDU1lrpuQl5ZL55/L1eq/JlR2dWx052Uh/RYs9okh3XZHFlIJXHZqjqyjEn4WdbOMfBj7vvc2WVQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "rdf-js": "*"
       }
     },
     "@types/resolve": {
@@ -2536,9 +2760,9 @@
       }
     },
     "@types/semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.6.tgz",
+      "integrity": "sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==",
       "dev": true
     },
     "@types/serve-static": {
@@ -2552,12 +2776,12 @@
       }
     },
     "@types/sinon": {
-      "version": "9.0.10",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.10.tgz",
-      "integrity": "sha512-/faDC0erR06wMdybwI/uR8wEKV/E83T0k4sepIpB7gXuy2gzx2xiOjmztq6a2Y6rIGJ04D+6UU0VBmWy+4HEMA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.2.tgz",
+      "integrity": "sha512-BHn8Bpkapj8Wdfxvh2jWIUoaYB/9/XhsL0oOvBfRagJtKlSl9NWPcFOz2lRukI9szwGxFtYZCTejJSqsGDbdmw==",
       "dev": true,
       "requires": {
-        "@types/sinonjs__fake-timers": "*"
+        "@sinonjs/fake-timers": "^7.1.0"
       }
     },
     "@types/sinon-chai": {
@@ -2570,12 +2794,6 @@
         "@types/sinon": "*"
       }
     },
-    "@types/sinonjs__fake-timers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
-      "dev": true
-    },
     "@types/spark-md5": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/spark-md5/-/spark-md5-3.0.2.tgz",
@@ -2583,12 +2801,12 @@
       "dev": true
     },
     "@types/sparqljs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.1.tgz",
-      "integrity": "sha512-S/+x6MDEBzVlLvBhsH/r6UvD3I0jXYpWiahCNkcmd8Dli6brxAiTorQ1ZKIGpPgP1tmZrmuQ075Fi7KIrrMXDA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.2.tgz",
+      "integrity": "sha512-tLfrnBuK37P2Bn8Fo7Qik95sBXYHw5D+gq3MMq1HVyoTpCWivwPnP0Mmd7Apamdc9eH3mLJwIZIETHCQ6HxMUw==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "*"
+        "rdf-js": "^4.0.2"
       }
     },
     "@types/uritemplate": {
@@ -2604,9 +2822,9 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.5.tgz",
+      "integrity": "sha512-8mbDgtc8xpxDDem5Gwj76stBDJX35KQ3YBoayxlqUQcL5BZUthiqP/VQ4PQnLHqM4PmlbyO74t98eJpURO+gPA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -2632,9 +2850,9 @@
       }
     },
     "@web/browser-logs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.2.1.tgz",
-      "integrity": "sha512-nSfRl/+7XQOtXBBJ9FMdXAb1bzytud1LeJAJmBX4bsfMDDcfrr4vNhiX4OnQ5tBYsXoiQse8ZvwngFM2O6PD3A==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.2.4.tgz",
+      "integrity": "sha512-11DAAv8ZqbO267dwBLXtvmDoJXXucG5n+i9oQQEEVgbgXKOvK/7eqGhrSDKuZ7TTTkSci9fW7ZcuKFtaKskAIA==",
       "dev": true,
       "requires": {
         "errorstacks": "^2.2.0"
@@ -2650,17 +2868,17 @@
       }
     },
     "@web/dev-server": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.8.tgz",
-      "integrity": "sha512-HBxzKfRf2XENgTDgCRQ+dQ4F5TQFAMvsr5mB/KYBWKMJJ4PXHRYbfCFvhAgq6s2CrZzicGWp7VZpMHLEVjEqpQ==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.17.tgz",
+      "integrity": "sha512-2gdOjkQp97uaORkOL8X90f4retqZ2lA9YqHDljpf4SFg0JWoY8X7EJA9XQG1jJ2x46oQ5zqJX7AiSWc47B2k6A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.11",
         "@rollup/plugin-node-resolve": "^11.0.1",
         "@types/command-line-args": "^5.0.0",
         "@web/config-loader": "^0.1.3",
-        "@web/dev-server-core": "^0.3.7",
-        "@web/dev-server-rollup": "^0.3.2",
+        "@web/dev-server-core": "^0.3.12",
+        "@web/dev-server-rollup": "^0.3.3",
         "camelcase": "^6.2.0",
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
@@ -2668,7 +2886,7 @@
         "debounce": "^1.2.0",
         "deepmerge": "^4.2.2",
         "ip": "^1.1.5",
-        "open": "^7.3.0",
+        "open": "^8.0.2",
         "portfinder": "^1.0.28"
       },
       "dependencies": {
@@ -2681,9 +2899,9 @@
       }
     },
     "@web/dev-server-core": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.3.7.tgz",
-      "integrity": "sha512-uJJMe8V2hLTM6EYrmlzldT7W5TH0L6Sn2DX1YvNT6fx+ztNDhDwH46RJwmDix3+fUqP9Th0iaZ/BJc45T76+Bw==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.3.13.tgz",
+      "integrity": "sha512-bGJHPeFRWATNfuL9Pp2LfqhnmqhBCc5eOO5AWQa0X+WQAwHiFo6xZNfsvsnJ1gvxXgsE4jKBAGu9lQRisvFRFA==",
       "dev": true,
       "requires": {
         "@types/koa": "^2.11.6",
@@ -2691,7 +2909,7 @@
         "@web/parse5-utils": "^1.2.0",
         "chokidar": "^3.4.3",
         "clone": "^2.1.2",
-        "es-module-lexer": "^0.3.26",
+        "es-module-lexer": "^0.4.0",
         "get-stream": "^6.0.0",
         "is-stream": "^2.0.0",
         "isbinaryfile": "^4.0.6",
@@ -2707,9 +2925,9 @@
       }
     },
     "@web/dev-server-rollup": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.2.tgz",
-      "integrity": "sha512-c5ROnMAUrOJPXTQFFXZiOy0ta4Y5yXLA2QkD71htNhIcqeOI4yx6ueDtuFqovRxVI0qcWGk46UdfZ0UGT/9MIg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.4.tgz",
+      "integrity": "sha512-QFaqHpJXri1TuN1yN0N670bxF5noC1RtIHPhoM5Sp6YX7v3610Z/fq465V7fNaeHnTNN7dIUmNkK9vqLIrsYTg==",
       "dev": true,
       "requires": {
         "@web/dev-server-core": "^0.3.3",
@@ -2720,9 +2938,9 @@
       }
     },
     "@web/parse5-utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-1.2.1.tgz",
-      "integrity": "sha512-FX5evV+qf5GjnNtvyHhuVKPVFqnSSECp0MnMtRLL63GV3aygiKe6B+Iqt6Xn0n1NsfKyh7zo2pw/rk0JtG2Vpw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-1.2.2.tgz",
+      "integrity": "sha512-B68DoJ5qF8Cu3o7nDA2RQTCf9bslVz2b0WHTk3qir5YCbWfhnPEGhDOedOjbE8xDiHqgzI1zXQsJ2+655aluLA==",
       "dev": true,
       "requires": {
         "@types/parse5": "^5.0.3",
@@ -2738,24 +2956,23 @@
       }
     },
     "@web/test-runner": {
-      "version": "0.12.15",
-      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.12.15.tgz",
-      "integrity": "sha512-v9VehhdoELkPs9u0XQrXu8BKzIRlx/U8F8YLsz8tV/bi8Mb7Riqvku0OdFu1P4vjf4NnElpx9J97/WBXURBwLg==",
+      "version": "0.12.20",
+      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.12.20.tgz",
+      "integrity": "sha512-ibuZDuvXy30PWn05//ca06f2NCr0WM42m0QyNdQZ/GIR03W4FpNQ/6ogSq4O4mTBg1KW88IOfHvEXWL449bR6g==",
       "dev": true,
       "requires": {
         "@web/browser-logs": "^0.2.0",
         "@web/config-loader": "^0.1.3",
-        "@web/dev-server": "^0.1.7",
+        "@web/dev-server": "^0.1.11",
         "@web/test-runner-chrome": "^0.9.4",
-        "@web/test-runner-commands": "^0.4.1",
-        "@web/test-runner-core": "^0.10.11",
+        "@web/test-runner-commands": "^0.4.3",
+        "@web/test-runner-core": "^0.10.14",
         "@web/test-runner-mocha": "^0.7.2",
         "camelcase": "^6.2.0",
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
         "command-line-usage": "^6.1.1",
         "convert-source-map": "^1.7.0",
-        "deepmerge": "^4.2.2",
         "diff": "^5.0.0",
         "globby": "^11.0.1",
         "portfinder": "^1.0.28",
@@ -2789,18 +3006,27 @@
       }
     },
     "@web/test-runner-commands": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.4.1.tgz",
-      "integrity": "sha512-y1U9+jucQ1ZB9YRgMFIjXTUSu/in54yt4Lf4GcY9fHoSyGVWDub085ARWipmagsD9SRN1QnIYTkMk+jRa/EiLQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.4.5.tgz",
+      "integrity": "sha512-jbhsS+nZmnbZPj/XL/g4se1c9TRtIgwrlYpaIIcWkHhCu5mKbdipgZ/nlFIhFS9UaVY52NiulmVj6dhAx7w4SA==",
       "dev": true,
       "requires": {
-        "@web/test-runner-core": "^0.10.8"
+        "@web/test-runner-core": "^0.10.14",
+        "mkdirp": "^1.0.4"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
       }
     },
     "@web/test-runner-core": {
-      "version": "0.10.12",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.10.12.tgz",
-      "integrity": "sha512-jAwkEtUPp1+oX32aok/L5aOaWt+H53g6t/ok1D/bzn4qdtnxlT9SaSO+n5vykbxbrnIfyzC3GvB3Jzv8Zcxl9w==",
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.10.18.tgz",
+      "integrity": "sha512-4emmE7tPMh5Wt/79tM1YYcBBnhBc4ecQxTtuyIIDeLPX8mtJoOx9OcP/V4baWDGOpNt6F4Ir6ELpOsconCISoA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.11",
@@ -2811,21 +3037,21 @@
         "@types/istanbul-reports": "^3.0.0",
         "@types/uuid": "^8.3.0",
         "@web/browser-logs": "^0.2.1",
-        "@web/dev-server-core": "^0.3.6",
+        "@web/dev-server-core": "^0.3.12",
         "chalk": "^4.1.0",
         "chokidar": "^3.4.3",
         "cli-cursor": "^3.1.0",
         "co-body": "^6.1.0",
         "convert-source-map": "^1.7.0",
         "debounce": "^1.2.0",
-        "dependency-graph": "^0.10.0",
+        "dependency-graph": "^0.11.0",
         "globby": "^11.0.1",
         "ip": "^1.1.5",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.0.2",
         "log-update": "^4.0.0",
-        "open": "^7.3.0",
+        "open": "^8.0.2",
         "picomatch": "^2.2.2",
         "source-map": "^0.7.3",
         "uuid": "^8.3.2"
@@ -2844,9 +3070,9 @@
       }
     },
     "@web/test-runner-mocha": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-mocha/-/test-runner-mocha-0.7.2.tgz",
-      "integrity": "sha512-UsaLvJ0k5Kb53WegF0J0pmKxCLdo6Nxl7GHYykO7m99Irz+jIGXV7VJP9/b8t+HH3fHyqB2Nmd5q9oxXwIJyNw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-mocha/-/test-runner-mocha-0.7.3.tgz",
+      "integrity": "sha512-EbJydgh9Peo74SR0WjAEXs9X64ec41RaSXp4yXCup7jzvzH/5mQd2kZ/ga9F8Jh3zcKknR+s59JLVivgc5Ni7A==",
       "dev": true,
       "requires": {
         "@types/mocha": "^8.2.0",
@@ -2854,22 +3080,22 @@
       },
       "dependencies": {
         "@types/mocha": {
-          "version": "8.2.1",
-          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.1.tgz",
-          "integrity": "sha512-NysN+bNqj6E0Hv4CTGWSlPzMW6vTKjDpOteycDkV4IWBsO+PU48JonrPzV9ODjiI2XrjmA05KInLgF5ivZ/YGQ==",
+          "version": "8.2.2",
+          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
+          "integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
           "dev": true
         }
       }
     },
     "@web/test-runner-playwright": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.8.4.tgz",
-      "integrity": "sha512-9RCez2kB0AocMasrUsmx/yW7FGSjBI9aEtjYzkFvRJF21IsEyjCrmmGPdBIa75a/gU2ydPaw0EQW4TDF5L4yRw==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.8.6.tgz",
+      "integrity": "sha512-GjjCd5MtCxmCsNlfe4HmmRyTg1S1SMAn0+i+2yhG9pvYwSJWLmLqN4AE39ZhlhuPh79spSVU889F6CGEXZGXPg==",
       "dev": true,
       "requires": {
         "@web/test-runner-core": "^0.10.8",
         "@web/test-runner-coverage-v8": "^0.4.5",
-        "playwright": "^1.7.1"
+        "playwright": "^1.8.1"
       }
     },
     "@webcomponents/shadycss": {
@@ -2938,14 +3164,19 @@
       }
     },
     "amf-client-js": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.7.0.tgz",
-      "integrity": "sha512-rl3TFIoIab7iulTzw3a3WCaf18TIavWFQxlevzipoO/c8B1B91K9TUzGVqhYWuKhDcsMxYe1mACX5J7vI52nUQ==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.7.4.tgz",
+      "integrity": "sha512-oTWKa1mGp5kNF+CXa+AFs8htMZvj2fyZYJZOVi1fr7/F2Ls+bxOPmTs+dJV4LVLh/WwGf8/2vf+wyEVsR0Xm1w==",
       "dev": true,
       "requires": {
         "ajv": "6.5.2",
         "amf-shacl-node": "2.0.0"
       }
+    },
+    "amf-json-ld-lib": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/amf-json-ld-lib/-/amf-json-ld-lib-0.0.13.tgz",
+      "integrity": "sha512-jv+jCh8kUb1+Ln9tKx7HvxlktxicBe2Pvxxmvoh/BN1ESFQnY3Xsm0X2I6CqcaVPdoDlyyRj7JM58YFXti+7vQ=="
     },
     "amf-shacl-node": {
       "version": "2.0.0",
@@ -2966,18 +3197,18 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.11.0"
+        "type-fest": "^0.21.3"
       },
       "dependencies": {
         "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
           "dev": true
         }
       }
@@ -3021,9 +3252,9 @@
       "dev": true
     },
     "anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -3128,15 +3359,15 @@
       "dev": true
     },
     "asynciterator": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.0.3.tgz",
-      "integrity": "sha512-mNvEwsk6DN7+co9T2be/Eor0kKQGIXCoGg27v7vsCLlFdSXlboH06UGCy9cfEh2qAfDdgsEpmDn6y59f3+ZvgA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.1.0.tgz",
+      "integrity": "sha512-+iDz8roOCGT+hvhhJ+GsQliEEB4Qd1QL1RIsllssZ3MkrtBGqc5Uwi3n5LcLp2f3rXRK07+qJPZQO+YvFCQzug==",
       "dev": true
     },
     "asyncjoin": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.0.2.tgz",
-      "integrity": "sha512-q5p5mqVXiL7KD6ihJad+6vaLHEQ73u5K5UyKerVGRA3Ec4AuhaoxpRU/qtQiV1eK2gMiO9T4OMSIG90hY1Fl+g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.0.3.tgz",
+      "integrity": "sha512-wBlf3sOdmUwbFW+zq1HBeOLdQAThSaFfTcdTFZGdB6OVR5VsIKZTycIC8ykDnzJhaZH2OaP23tru1DlLJvrRjA==",
       "dev": true,
       "requires": {
         "asynciterator": "^3.0.0"
@@ -3149,9 +3380,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.2.tgz",
-      "integrity": "sha512-V+Nq70NxKhYt89ArVcaNL9FDryB3vQOd+BFXZIfO3RP6rwtj+2yqqqdHEkacutglPaZLkJeuXKCjCJDMGPtPqg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.3.tgz",
+      "integrity": "sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==",
       "dev": true
     },
     "axobject-query": {
@@ -3161,9 +3392,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "base64-js": {
@@ -3292,9 +3523,9 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.1.tgz",
-      "integrity": "sha512-JClPZFGRcSl7X8dYzlCJY7v+X1fBA+9Y339Y8EqhBVfp0QC1hTnaf7nMfR+XZ74clkBC64b0iEw2cWKHt3EVqA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
@@ -3315,9 +3546,9 @@
       }
     },
     "chai-dom": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.8.2.tgz",
-      "integrity": "sha512-kk2SnCuJliouO5M58OjA7M8VXN338WAxHOm+LbpjeL09pJgRpXugSC5aj8uwFm/6Lmpcdtq7hf+DldTdBm5/Sw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.9.0.tgz",
+      "integrity": "sha512-UXSbhcGVBWv/5qVqbJY/giTDRyo3wKapUsWluEuVvxcJLFXkyf8l4D2PTd6trzrmca6WWnGdpaFkYdl1P0WjtA==",
       "dev": true
     },
     "chalk": {
@@ -3337,19 +3568,19 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "chownr": {
@@ -3417,9 +3648,9 @@
       }
     },
     "clipboard": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
-      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3489,14 +3720,20 @@
       "dev": true
     },
     "color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
       "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
     },
     "colors": {
       "version": "1.4.0",
@@ -3548,9 +3785,9 @@
           }
         },
         "array-back": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
           "dev": true
         },
         "chalk": {
@@ -3610,9 +3847,9 @@
       "dev": true
     },
     "componentsjs": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-4.0.6.tgz",
-      "integrity": "sha512-MPvKSLVo4SX3PafGMqKPzV+i8JdivYXuaJb2CsEF86TUgniXX3i661D0MDBwMWnd0LXWbI1sNq0kKJBKrL/wBw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-4.3.0.tgz",
+      "integrity": "sha512-jjts3ITImm6hMVfDAEIkIZTyKaLHkOlo89oBxlH7J0ukVpptZLB/Gi29LY8GtUgExoTd6gd3mTWXB7xp3cGKwA==",
       "dev": true,
       "requires": {
         "@types/minimist": "^1.2.0",
@@ -3623,11 +3860,19 @@
         "minimist": "^1.2.0",
         "rdf-data-factory": "^1.0.4",
         "rdf-object": "^1.8.0",
-        "rdf-parse": "^1.7.0",
+        "rdf-parse": "^1.8.1",
         "rdf-quad": "^1.5.0",
         "rdf-terms": "^1.6.2",
         "semver": "^7.3.2",
         "winston": "^3.3.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.17.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
+          "integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A==",
+          "dev": true
+        }
       }
     },
     "concat-map": {
@@ -3640,12 +3885,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
       "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
-      "dev": true
-    },
-    "contains-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "content-disposition": {
@@ -3682,9 +3921,9 @@
       }
     },
     "conventional-changelog-conventionalcommits": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.5.0.tgz",
-      "integrity": "sha512-buge9xDvjjOxJlyxUnar/+6i/aVEVGA7EEh4OafBCXPlLUQPGbRUBhBUveWRxzvR8TEjhKEP4BdepnpG2FSZXw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.0.tgz",
+      "integrity": "sha512-sj9tj3z5cnHaSJCYObA9nISf7eq/YjscLPoq6nmew4SiOjxqL2KRpK20fjnjVbpNDjJ2HR3MoVcWKXwbVvzS0A==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
@@ -3708,9 +3947,9 @@
       }
     },
     "convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -3735,15 +3974,15 @@
       }
     },
     "core-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.1.tgz",
+      "integrity": "sha512-h8VbZYnc9pDzueiS2610IULDkpFFPunHwIpl8yRwFahAEEdSpHlTy3h3z3rKq5h11CaUdBEeRViu9AYvbxiMeg==",
       "dev": true
     },
     "core-js-pure": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.1.tgz",
-      "integrity": "sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.1.tgz",
+      "integrity": "sha512-OZuWHDlYcIda8sJLY4Ec6nWq2hRjlyCqCZ+jCflyleMkVt3tPedDVErvHslyS2nbO+SlBFMSBJYvtLMwxnrzjA==",
       "dev": true
     },
     "core-util-is": {
@@ -3766,9 +4005,9 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "dev": true,
       "requires": {
         "node-fetch": "2.6.1"
@@ -3801,9 +4040,9 @@
       "dev": true
     },
     "debounce": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
-      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
       "dev": true
     },
     "debug": {
@@ -3840,9 +4079,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
     "dedent": {
@@ -3884,6 +4123,12 @@
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -3913,9 +4158,9 @@
       "dev": true
     },
     "dependency-graph": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.10.0.tgz",
-      "integrity": "sha512-c9amUgpgxSi1bE5/sbLwcs5diLD0ygCQYmhfM5H1s5VH1mCsYkcmAL3CcNdv4kdSw6JuMoHeDGzLgj/gAXdWVg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
       "dev": true
     },
     "destroy": {
@@ -3955,13 +4200,13 @@
       }
     },
     "dom-serializer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
-      "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
       }
     },
@@ -3985,29 +4230,29 @@
       }
     },
     "domelementtype": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
       "dev": true
     },
     "domhandler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-      "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
       "dev": true,
       "requires": {
-        "domelementtype": "^2.1.0"
+        "domelementtype": "^2.2.0"
       }
     },
     "domutils": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-      "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0"
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       }
     },
     "dot-prop": {
@@ -4085,15 +4330,15 @@
       }
     },
     "errorstacks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.3.0.tgz",
-      "integrity": "sha512-VjCIUbEyLymy2N1M/uTniewz+j69YC2R7Sp1UiJn04RHwyIniBib6hUZwgmphAAZTOk7LRg/wryGFEJhblEd7Q==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.3.2.tgz",
+      "integrity": "sha512-cJp8qf5t2cXmVZJjZVrcU4ODFJeQOcUyjJEtPFtWO+3N6JPM6vCe4Sfv3cwIs/qS7gnUo/fvKX/mDCVQZq+P7A==",
       "dev": true
     },
     "es-abstract": {
-      "version": "1.18.0-next.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.3.tgz",
-      "integrity": "sha512-VMzHx/Bczjg59E6jZOQjHeN3DEoptdhejpARgflAViidlqSpjdq9zA6lKwlhRRs/lOw1gHJv2xkkSFRgvEwbQg==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+      "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -4104,20 +4349,20 @@
         "has-symbols": "^1.0.2",
         "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.2",
-        "is-string": "^1.0.5",
-        "object-inspect": "^1.9.0",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.10.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.0"
+        "unbox-primitive": "^1.0.1"
       }
     },
     "es-module-lexer": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
-      "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
+      "integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
       "dev": true
     },
     "es-to-primitive": {
@@ -4144,29 +4389,31 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
-      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-82G/JToB9qIy/ArBzIWG9xvvwL3R86AlCjtGw+A29OMZDqhTybz/MByORSukGxeI+YPCR4coYyITKk8BFH9nDA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.0",
+        "@eslint/eslintrc": "^0.4.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -4174,7 +4421,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -4183,7 +4430,7 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.4",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -4217,6 +4464,12 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
         },
         "fast-deep-equal": {
           "version": "3.1.3",
@@ -4260,76 +4513,71 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+      "integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
+        "debug": "^3.2.7",
         "pkg-dir": "^2.0.0"
-      }
-    },
-    "eslint-plugin-html": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-6.1.1.tgz",
-      "integrity": "sha512-JSe3ZDb7feKMnQM27XWGeoIjvP4oWQMJD9GZ6wW67J7/plVL87NK72RBwlvfc3tTZiYUchHhxAwtgEd1GdofDA==",
-      "dev": true,
-      "requires": {
-        "htmlparser2": "^5.0.1"
       },
       "dependencies": {
-        "domhandler": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
-            "domelementtype": "^2.0.1"
+            "ms": "^2.1.1"
           }
         },
-        "htmlparser2": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
-          "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^3.3.0",
-            "domutils": "^2.4.2",
-            "entities": "^2.0.0"
-          }
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
         }
       }
     },
-    "eslint-plugin-import": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+    "eslint-plugin-html": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-6.1.2.tgz",
+      "integrity": "sha512-bhBIRyZFqI4EoF12lGDHAmgfff8eLXx6R52/K3ESQhsxzCzIE6hdebS7Py651f7U3RBotqroUnC3L29bR7qJWQ==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.1",
-        "array.prototype.flat": "^1.2.3",
-        "contains-path": "^0.1.0",
+        "htmlparser2": "^6.0.1"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.23.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+      "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.3",
+        "array.prototype.flat": "^1.2.4",
         "debug": "^2.6.9",
-        "doctrine": "1.5.0",
+        "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.4",
-        "eslint-module-utils": "^2.6.0",
+        "eslint-module-utils": "^2.6.1",
+        "find-up": "^2.0.0",
         "has": "^1.0.3",
+        "is-core-module": "^2.4.0",
         "minimatch": "^3.0.4",
-        "object.values": "^1.1.1",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.17.0",
+        "object.values": "^1.1.3",
+        "pkg-up": "^2.0.0",
+        "read-pkg-up": "^3.0.0",
+        "resolve": "^1.20.0",
         "tsconfig-paths": "^3.9.0"
       },
       "dependencies": {
         "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "^2.0.2"
           }
         },
         "find-up": {
@@ -4342,9 +4590,9 @@
           }
         },
         "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
           "dev": true
         },
         "locate-path": {
@@ -4400,33 +4648,33 @@
           "dev": true
         },
         "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "^3.0.0"
           }
         },
         "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^2.0.0",
+            "load-json-file": "^4.0.0",
             "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
             "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "read-pkg": "^3.0.0"
           }
         },
         "semver": {
@@ -4438,9 +4686,9 @@
       }
     },
     "eslint-plugin-lit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-lit/-/eslint-plugin-lit-1.3.0.tgz",
-      "integrity": "sha512-fy6Lr5vYI3kvCYaDXA20lwyKAp1keS9UjR5ntj8U2TeV+1yUta3S7xxXe+rABKRPbcNzi1ZvQLE1LmNKc9yr4Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-lit/-/eslint-plugin-lit-1.5.1.tgz",
+      "integrity": "sha512-pYB0QM11uyOk5L55QfGhBmWi8a56PkNsnx+zVpY4bxz9YVquEo4BeRnFmf9AwFyT89rhGud9QruFhM2xJ4piwg==",
       "dev": true,
       "requires": {
         "parse5": "^6.0.1",
@@ -4488,9 +4736,9 @@
       }
     },
     "eslint-plugin-no-only-tests": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz",
-      "integrity": "sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
       "dev": true
     },
     "eslint-plugin-wc": {
@@ -4537,9 +4785,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
     "espree": {
@@ -4748,17 +4996,19 @@
       }
     },
     "fecha": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
-      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
       "dev": true
     },
     "fetch-sparql-endpoint": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-1.9.0.tgz",
-      "integrity": "sha512-iACwPeKhvy5aM2rbzdnKOUWHLM3tW+odZ88pdPG+xCXSTGMtWBI8FP8fqgHcZsxNq9NfRU7+pMsMsU5JCNabCA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-2.0.2.tgz",
+      "integrity": "sha512-aWaG8Djz5WbId9m1puXch0oXey6GboTE7iog0kL8W11qszbowfStB/a4uIj6Yc/3qSvI1yrnTO0zqQlYpmMPQg==",
       "dev": true,
       "requires": {
+        "@types/rdf-js": "*",
+        "@types/sparqljs": "^3.0.1",
         "cross-fetch": "^3.0.6",
         "is-stream": "^2.0.0",
         "minimist": "^1.2.0",
@@ -4769,15 +5019,6 @@
         "sparqlxml-parse": "^1.4.0",
         "stream-to-string": "^1.1.0",
         "web-streams-node": "^0.4.0"
-      }
-    },
-    "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4858,9 +5099,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
       "dev": true
     },
     "fresh": {
@@ -4876,14 +5117,14 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       }
     },
     "fs.realpath": {
@@ -4947,9 +5188,9 @@
       "dev": true
     },
     "get-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true
     },
     "git-raw-commits": {
@@ -4966,9 +5207,9 @@
       }
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -4980,9 +5221,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -4998,26 +5239,26 @@
       }
     },
     "globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
       },
       "dependencies": {
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
       }
     },
     "globby": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-      "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
@@ -5053,9 +5294,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
       "dev": true
     },
     "graphql-ld": {
@@ -5158,9 +5399,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
-      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -5173,14 +5414,14 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.0.tgz",
-      "integrity": "sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
-        "domutils": "^2.4.4",
+        "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
     },
@@ -5451,9 +5692,9 @@
       "dev": true
     },
     "is-bigint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
       "dev": true
     },
     "is-binary-path": {
@@ -5466,12 +5707,12 @@
       }
     },
     "is-boolean-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2"
       }
     },
     "is-buffer": {
@@ -5487,24 +5728,24 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
     },
     "is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+      "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
       "dev": true
     },
     "is-docker": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true
     },
     "is-extglob": {
@@ -5526,9 +5767,9 @@
       "dev": true
     },
     "is-generator-function": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
-      "integrity": "sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+      "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A==",
       "dev": true
     },
     "is-glob": {
@@ -5559,9 +5800,9 @@
       "dev": true
     },
     "is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
       "dev": true
     },
     "is-obj": {
@@ -5577,19 +5818,19 @@
       "dev": true
     },
     "is-potential-custom-element-name": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
-      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
     "is-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.2"
       }
     },
     "is-regexp": {
@@ -5605,18 +5846,18 @@
       "dev": true
     },
     "is-string": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.2"
       }
     },
     "is-text-path": {
@@ -5627,6 +5868,12 @@
       "requires": {
         "text-extensions": "^1.0.0"
       }
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -5650,9 +5897,9 @@
       "dev": true
     },
     "isbinaryfile": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.6.tgz",
-      "integrity": "sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.8.tgz",
+      "integrity": "sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==",
       "dev": true
     },
     "isexe": {
@@ -5716,6 +5963,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -5750,18 +6003,19 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
       }
     },
     "jsonld-context-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.1.tgz",
-      "integrity": "sha512-7yKhnwFaiCnDPUZYQuAWyT0zZBfOKZDyjtqFVNbXrYRkboU+m55UsastsfXbo7qNroTGdFiEyxHEHDEfBC0P4Q==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.2.tgz",
+      "integrity": "sha512-zAhus+dz4IrXiYAiYf6M1PSdYkILVWPg4bqqGfim+rGrmVc3d0drFAriLOU2RMwQFKljM+41lJTau47sxt6YWA==",
       "dev": true,
       "requires": {
         "@types/http-link-header": "^1.0.1",
@@ -5773,24 +6027,24 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.45.tgz",
-          "integrity": "sha512-703YTEp8AwQeapI0PTXDOj+Bs/mtdV/k9VcTP7z/de+lx6XjFMKdB+JhKnK+6PZ5za7omgZ3V6qm/dNkMj/Zow==",
+          "version": "13.13.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
           "dev": true
         }
       }
     },
     "jsonld-streaming-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.2.1.tgz",
-      "integrity": "sha512-KRCcRQGYDH9AO+VgLgbC1AwUKeVs3SpFONiABhBvcIZjErbsXxmiXiUtSYor0CrtWGLjVMoEZA5jCFUsO3Kezw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.3.2.tgz",
+      "integrity": "sha512-C9hyL5LRb2K0eaS5biP+ixUtMjr3UPJn9WInNYAmjX9tL7NzeSw3lY7nW3GEnKETxF3I3btvEPR1Nm/+tHMWZQ==",
       "dev": true,
       "requires": {
         "@types/http-link-header": "^1.0.1",
         "@types/rdf-js": "*",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.1.1",
+        "jsonld-context-parser": "^2.1.2",
         "jsonparse": "^1.3.1",
         "rdf-data-factory": "^1.0.4"
       }
@@ -5812,9 +6066,9 @@
       "dev": true
     },
     "just-extend": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
-      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
     },
     "keygrip": {
@@ -6030,12 +6284,13 @@
           }
         },
         "log-symbols": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
           "dev": true,
           "requires": {
-            "chalk": "^4.0.0"
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
           }
         },
         "ms": {
@@ -6047,18 +6302,16 @@
       }
     },
     "listr2": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.3.4.tgz",
-      "integrity": "sha512-b0lhLAvXSr63AtPF9Dgn6tyxm8Kiz6JXpVGM0uZJdnDcZp02jt7FehgAnMfA9R7riQimOKjQgLknBTdz2nmXwQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.10.0.tgz",
+      "integrity": "sha512-eP40ZHihu70sSmqFNbNy2NL1YwImmlMmPh9WO5sLmPDleurMHt3n+SwEWNu2kzKScexZnkyFtc1VI0z/TGlmpw==",
       "dev": true,
       "requires": {
-        "chalk": "^4.1.0",
         "cli-truncate": "^2.1.0",
-        "figures": "^3.2.0",
-        "indent-string": "^4.0.0",
+        "colorette": "^1.2.2",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
-        "rxjs": "^6.6.6",
+        "rxjs": "^6.6.7",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
@@ -6077,37 +6330,38 @@
       }
     },
     "lit-element": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
-      "integrity": "sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
+      "integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
       "requires": {
         "lit-html": "^1.1.1"
       }
     },
     "lit-html": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
-      "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
+      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
     },
     "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         }
       }
@@ -6133,16 +6387,28 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "lodash.uniqwith": {
@@ -6272,15 +6538,15 @@
       }
     },
     "map-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
       "dev": true
     },
     "marky": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
-      "integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.2.tgz",
+      "integrity": "sha512-k1dB2HNeaNyORco8ulVEhctyEGkKHb2YWAhDsxeFlW2nROIirsctBYzKwwS3Vza+sKTS1zO4Z+n9/+9WbGLIxQ==",
       "dev": true
     },
     "media-typer": {
@@ -6356,13 +6622,13 @@
       }
     },
     "micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "dev": true,
       "requires": {
         "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
+        "picomatch": "^2.2.3"
       }
     },
     "mime": {
@@ -6372,18 +6638,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.46.0"
+        "mime-db": "1.48.0"
       }
     },
     "mimic-fn": {
@@ -6734,9 +7000,9 @@
       "dev": true
     },
     "n3": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.8.1.tgz",
-      "integrity": "sha512-oS0XBNhHH+1TFByvJs84q2lsy3MqpkIeLNT8r9OPyblcvcQbZHcKspwdVcWWzNrlMpSHmbOG1KO5AbXy2++Csw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.10.0.tgz",
+      "integrity": "sha512-y+qpS0GktEBttOaDR+BF1t1G2fw4Xn4nCZWNn+7MvEmD2I4YpMH6OJF/xHKSwInCxOC9vu9eI6pluB9/RDUyZQ==",
       "dev": true,
       "requires": {
         "queue-microtask": "^1.1.2",
@@ -6772,6 +7038,17 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+          "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
       }
     },
     "node-environment-flags": {
@@ -6799,14 +7076,14 @@
       "dev": true
     },
     "normalize-package-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-      "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+      "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^3.0.6",
-        "resolve": "^1.17.0",
-        "semver": "^7.3.2",
+        "hosted-git-info": "^4.0.1",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
       }
     },
@@ -6832,9 +7109,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
       "dev": true
     },
     "object-keys": {
@@ -6856,15 +7133,14 @@
       }
     },
     "object.entries": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
-      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+      "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "has": "^1.0.3"
+        "es-abstract": "^1.18.2"
       }
     },
     "object.getownpropertydescriptors": {
@@ -6879,15 +7155,14 @@
       }
     },
     "object.values": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-      "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+      "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has": "^1.0.3"
+        "es-abstract": "^1.18.2"
       }
     },
     "on-finished": {
@@ -6933,13 +7208,14 @@
       "dev": true
     },
     "open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.2.1.tgz",
+      "integrity": "sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==",
       "dev": true,
       "requires": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       }
     },
     "opencollective-postinstall": {
@@ -7065,9 +7341,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -7106,15 +7382,15 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "pinkie": {
@@ -7192,10 +7468,70 @@
         }
       }
     },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "playwright": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.9.1.tgz",
-      "integrity": "sha512-bZXnks4UGJZoqja6TqVEUG0IQ2liqYFcO1R4lT43aO4oDVTQtawEJjS+EqLYsAuniRFWVE87Cemus4fRQbyXMg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.12.2.tgz",
+      "integrity": "sha512-tSZGeILY70T4imhCMCsvzhoaDm9baosIG5fQncSWprpjVc/X4yYdBQCLBMvOi98H50hvu9fhgy2hpsgFKCsUaw==",
       "dev": true,
       "requires": {
         "commander": "^6.1.0",
@@ -7210,7 +7546,8 @@
         "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
         "stack-utils": "^2.0.3",
-        "ws": "^7.3.1"
+        "ws": "^7.4.6",
+        "yazl": "^2.5.1"
       },
       "dependencies": {
         "agent-base": {
@@ -7429,15 +7766,18 @@
       "dev": true
     },
     "qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
-      "dev": true
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "dev": true,
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "queue-microtask": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
-      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
     "quick-lru": {
@@ -7489,13 +7829,23 @@
       }
     },
     "rdf-isomorphic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.2.0.tgz",
-      "integrity": "sha512-Dq+iuWrVuK7q3P4/nychbWhRJ1M5yMAekNJN8f5pjarE8SH9Duy/R0JopVF0I0Q2w0poZlsVKKIBpeG+AdOSAw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.2.1.tgz",
+      "integrity": "sha512-kIKlQYoizNqp8zhbca1zV3mYngisoD/KNt/xBRjagp7R3F8niI3b1vxvqcWlSkNXgPD6MsXpP2E/uXZ8oGTIcA==",
       "dev": true,
       "requires": {
+        "hash.js": "^1.1.7",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2"
+      }
+    },
+    "rdf-js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
+      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/types": "*"
       }
     },
     "rdf-literal": {
@@ -7509,9 +7859,9 @@
       }
     },
     "rdf-object": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.10.0.tgz",
-      "integrity": "sha512-FJ/PhF9zPrPkLTYFJ/pfpFzPxbBvARP1hVAG9TB7VRngWIGcvscs7RD6jjm+7dfq295Ibb3G3ZdBZf+U0klCXw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.10.2.tgz",
+      "integrity": "sha512-IvppylbhVlcbyxDuwJDLNYgUsX4m7Kztfa1B2zZzl7M8V6edmQqKglCFHZ93ZveQ6m9q1V1VTYLaGaB7p9no8Q==",
       "dev": true,
       "requires": {
         "jsonld-context-parser": "^2.0.2",
@@ -7521,28 +7871,28 @@
       }
     },
     "rdf-parse": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-1.7.0.tgz",
-      "integrity": "sha512-P3meLRU9OkZZz9OYq26VeRrxIDrzEBNAScAWcTX1tsf4Z85WTLhiwP5jC+OZBSzRSlybkkb6EYSVA1M4eykiBg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-1.8.1.tgz",
+      "integrity": "sha512-sNcQ1Vc8hDf/hVjVHYS9CSHyFShVX8LVwBrFARKkGgGe+K9DZJRaZQI06VCwmEW027ZFjfxFgmjQlc09FLmI4A==",
       "dev": true,
       "requires": {
-        "@comunica/actor-http-native": "~1.19.0",
-        "@comunica/actor-rdf-parse-html": "~1.19.0",
-        "@comunica/actor-rdf-parse-html-microdata": "~1.19.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "~1.19.0",
-        "@comunica/actor-rdf-parse-html-script": "~1.19.0",
-        "@comunica/actor-rdf-parse-jsonld": "~1.19.0",
-        "@comunica/actor-rdf-parse-n3": "~1.19.0",
-        "@comunica/actor-rdf-parse-rdfxml": "~1.19.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "~1.19.0",
-        "@comunica/bus-http": "~1.19.0",
-        "@comunica/bus-init": "~1.19.0",
-        "@comunica/bus-rdf-parse": "~1.19.0",
-        "@comunica/bus-rdf-parse-html": "~1.19.0",
-        "@comunica/core": "~1.19.0",
-        "@comunica/mediator-combine-union": "~1.19.0",
-        "@comunica/mediator-number": "~1.19.0",
-        "@comunica/mediator-race": "~1.19.0",
+        "@comunica/actor-http-native": "~1.21.1",
+        "@comunica/actor-rdf-parse-html": "~1.21.1",
+        "@comunica/actor-rdf-parse-html-microdata": "~1.21.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "~1.21.1",
+        "@comunica/actor-rdf-parse-html-script": "~1.21.1",
+        "@comunica/actor-rdf-parse-jsonld": "~1.21.2",
+        "@comunica/actor-rdf-parse-n3": "~1.21.1",
+        "@comunica/actor-rdf-parse-rdfxml": "~1.21.1",
+        "@comunica/actor-rdf-parse-xml-rdfa": "~1.21.1",
+        "@comunica/bus-http": "~1.21.1",
+        "@comunica/bus-init": "~1.21.1",
+        "@comunica/bus-rdf-parse": "~1.21.1",
+        "@comunica/bus-rdf-parse-html": "~1.21.1",
+        "@comunica/core": "~1.21.1",
+        "@comunica/mediator-combine-union": "~1.21.1",
+        "@comunica/mediator-number": "~1.21.1",
+        "@comunica/mediator-race": "~1.21.1",
         "@types/rdf-js": "*",
         "stream-to-string": "^1.2.0"
       }
@@ -7559,9 +7909,9 @@
       }
     },
     "rdf-store-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-1.1.0.tgz",
-      "integrity": "sha512-JWvQUv/1yja1TiEzhS1PTactSER9ORjM/6TV8z3KdGWpeQOs9TeUgLzx5PLXSRePFZ8GKNTkG5dD+wC6Yh3sbQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-1.2.0.tgz",
+      "integrity": "sha512-VpnXP+S90GmvZXKpmMEb8bwPFpeYIrL/tPGtTFumaYslbR/KYC68d2+QQZ4Mz63kptFw/uwnGcZ2budTFtJWqQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -7656,9 +8006,9 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
           "dev": true
         },
         "normalize-package-data": {
@@ -7724,9 +8074,9 @@
       "dev": true
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -7755,9 +8105,9 @@
       "dev": true
     },
     "regexpp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
     "relative-to-absolute-iri": {
@@ -7898,12 +8248,12 @@
       }
     },
     "rollup": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.40.0.tgz",
-      "integrity": "sha512-WiOGAPbXoHu+TOz6hyYUxIksOwsY/21TRWoO593jgYt8mvYafYqQl+axaA8y1z2HFazNUUrsMSjahV2A6/2R9A==",
+      "version": "2.52.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.3.tgz",
+      "integrity": "sha512-QF3Sju8Kl2z0osI4unyOLyUudyhOMK6G0AeqJWgfiyigqLAlnNrfBcDWDx+f1cqn+JU2iIYVkDrgQ6/KtwEfrg==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "run-parallel": {
@@ -7916,9 +8266,9 @@
       }
     },
     "rxjs": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-      "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -7960,9 +8310,9 @@
       "optional": true
     },
     "semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -8007,6 +8357,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -8036,6 +8397,15 @@
         "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+          "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -8045,9 +8415,9 @@
       }
     },
     "sinon-chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.5.0.tgz",
-      "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true
     },
     "slash": {
@@ -8080,9 +8450,9 @@
       "dev": true
     },
     "sparqlalgebrajs": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.2.tgz",
-      "integrity": "sha512-V91RelX3PehPr8pjVGw1pEcGLfla6vMlv/GSdQHOY7/Z++TqR+9LXFKiXxX3F+NXiIhkBxJ2Vf5HBhvCvSOx4Q==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+      "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
@@ -8102,9 +8472,9 @@
       }
     },
     "sparqlee": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.6.0.tgz",
-      "integrity": "sha512-jbPhD5FcRp2rORkZZ9L8kM4HAx7N9RQl6YbpvyQYcxjjvMtgZ1OL0OiSbmKy/ixt74ycXjNRYK5IWfL3sdH+NA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.6.2.tgz",
+      "integrity": "sha512-Wvp1wYrbzxHEEb4rXw7SfxILhrl+YlDBv4mS4FJqJxFpZbblgPIKlscyif8kB4kezJXCxXExzV/ArN231jKrfg==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "^4.0.0",
@@ -8122,9 +8492,9 @@
       }
     },
     "sparqljs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.0.tgz",
-      "integrity": "sha512-HDaHdFTTsC3eyGDVde01PbZalt0jP52U0y/iqC2VKyGbI1gg8anQNsisyqLeBd4ekkIkMdJbnSvfh43VlB3QyQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+      "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
       "dev": true,
       "requires": {
         "rdf-data-factory": "^1.0.4"
@@ -8143,9 +8513,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.45.tgz",
-          "integrity": "sha512-703YTEp8AwQeapI0PTXDOj+Bs/mtdV/k9VcTP7z/de+lx6XjFMKdB+JhKnK+6PZ5za7omgZ3V6qm/dNkMj/Zow==",
+          "version": "13.13.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
           "dev": true
         }
       }
@@ -8173,9 +8543,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.45.tgz",
-          "integrity": "sha512-703YTEp8AwQeapI0PTXDOj+Bs/mtdV/k9VcTP7z/de+lx6XjFMKdB+JhKnK+6PZ5za7omgZ3V6qm/dNkMj/Zow==",
+          "version": "13.13.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
           "dev": true
         }
       }
@@ -8207,9 +8577,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+      "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
       "dev": true
     },
     "split2": {
@@ -8388,21 +8758,23 @@
       }
     },
     "table": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
-      "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
       "dev": true,
       "requires": {
-        "ajv": "^7.0.2",
-        "lodash": "^4.17.20",
+        "ajv": "^8.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
-          "integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
+          "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -8426,9 +8798,9 @@
       }
     },
     "table-layout": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
-      "integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
       "dev": true,
       "requires": {
         "array-back": "^4.0.1",
@@ -8438,9 +8810,9 @@
       },
       "dependencies": {
         "array-back": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
           "dev": true
         },
         "typical": {
@@ -8532,18 +8904,18 @@
       "dev": true
     },
     "tr46": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"
       }
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
     "trim-off-newlines": {
@@ -8614,9 +8986,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
     },
     "typescript-lit-html-plugin": {
@@ -8656,15 +9028,15 @@
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
-      "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.0",
-        "has-symbols": "^1.0.0",
-        "which-boxed-primitive": "^1.0.1"
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
       }
     },
     "unbzip2-stream": {
@@ -8678,9 +9050,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
     "unpipe": {
@@ -8717,15 +9089,15 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz",
-      "integrity": "sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.2.tgz",
+      "integrity": "sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -8777,9 +9149,9 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
           "dev": true
         },
         "indent-string": {
@@ -8868,6 +9240,12 @@
             "pify": "^2.0.0",
             "pinkie-promise": "^2.0.0"
           }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
@@ -9030,13 +9408,13 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
-      "integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
+      "integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^2.0.2",
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
         "webidl-conversions": "^6.1.0"
       }
     },
@@ -9182,13 +9560,13 @@
       "dev": true
     },
     "wordwrapjs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
-      "integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
       "dev": true,
       "requires": {
         "reduce-flatten": "^2.0.0",
-        "typical": "^5.0.0"
+        "typical": "^5.2.0"
       },
       "dependencies": {
         "typical": {
@@ -9217,9 +9595,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
+      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
       "dev": true
     },
     "xml": {
@@ -9235,9 +9613,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yallist": {
@@ -9247,9 +9625,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
     "yargs": {
@@ -9284,9 +9662,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.6",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
-      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     },
     "yargs-unparser": {
@@ -9441,6 +9819,15 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3"
       }
     },
     "ylru": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-navigation",
   "description": "An element to display the response body",
-  "version": "4.2.8",
+  "version": "4.3.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiNavigation.d.ts
+++ b/src/ApiNavigation.d.ts
@@ -207,7 +207,7 @@ export declare class ApiNavigation {
    * of which endpoint was first in the list, relative to each other
    * @attribute
    */
-  sortEndpoints: boolean;
+  rearrangeEndpoints: boolean;
 
   /**
    * Enables compatibility with Anypoint components.
@@ -332,7 +332,7 @@ export declare class ApiNavigation {
   /**
    * Sort endpoints alphabetically based on path
    */
-  _sortEndpoints(endpoints: EndpointItem[]): EndpointItem[];
+  _rearrangeEndpoints(endpoints: EndpointItem[]): EndpointItem[];
 
   /**
    * Transforms a list of endpoints into a map that goes from

--- a/src/ApiNavigation.d.ts
+++ b/src/ApiNavigation.d.ts
@@ -207,7 +207,7 @@ export declare class ApiNavigation {
    * of which endpoint was first in the list, relative to each other
    * @attribute
    */
-  rearrangeEndpoints: boolean;
+  sortEndpoints: boolean;
 
   /**
    * Enables compatibility with Anypoint components.
@@ -323,11 +323,9 @@ export declare class ApiNavigation {
   _traverseEncodes(model: object, target: TargetModel): void;
 
   /**
-   * Re-arrange the endpoints in relative order to each other, keeping
-   * the first endpoints to appear first, and the last endpoints to appear
-   * last
+   * Sort endpoints alphabetically based on path
    */
-  _rearrangeEndpoints(endpoints: EndpointItem[]): EndpointItem[];
+  _sortEndpoints(endpoints: EndpointItem[]): EndpointItem[];
 
   /**
    * Transforms a list of endpoints into a map that goes from

--- a/src/ApiNavigation.d.ts
+++ b/src/ApiNavigation.d.ts
@@ -228,6 +228,13 @@ export declare class ApiNavigation {
   noOverview: boolean;
 
   /**
+   * When set, avoiids truncating and indentation of endpoint paths.
+   * Instead, the full path for each endpoint will be rendered.
+   * @attribute
+   */
+  renderFullPaths: boolean;
+
+  /**
    * true when `_docs` property is set with values
    */
   get hasDocs(): boolean;

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -240,7 +240,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
        * If this value is set, then the navigation component will sort the list
        * of endpoints alphabetically based on the `path` value of the endpoint
        */
-      sortEndpoints: { type: Boolean },
+      rearrangeEndpoints: { type: Boolean },
       /**
        * Enables compatibility with Anypoint components.
        */
@@ -446,18 +446,18 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     this._items = null;
   }
 
-  set sortEndpoints(value) {
-    const old = this.__sortEndpoints;
+  set rearrangeEndpoints(value) {
+    const old = this.__rearrangeEndpoints;
     if (old === value) {
       return;
     }
-    this.__sortEndpoints = value;
-    this.requestUpdate('sortEndpoints', old);
+    this.__rearrangeEndpoints = value;
+    this.requestUpdate('rearrangeEndpoints', old);
     this.__amfChanged(this.amf);
   }
 
-  get sortEndpoints() {
-    return this.__sortEndpoints;
+  get rearrangeEndpoints() {
+    return this.__rearrangeEndpoints;
   }
 
   set renderFullPaths(value) {
@@ -483,7 +483,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     this.noink = false;
     this.allowPaths = false;
     this.compatibility = false;
-    this.sortEndpoints = false;
+    this.rearrangeEndpoints = false;
     this.indentSize = 8;
     this._selectedItem = null;
     this.aware = null;
@@ -732,8 +732,8 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     }
     const eKey = this._getAmfKey(this.ns.aml.vocabularies.apiContract.endpoint);
     let endpoint = this._ensureArray(data[eKey]);
-    if (this.sortEndpoints) {
-      endpoint = this._sortEndpoints(endpoint);
+    if (this.rearrangeEndpoints) {
+      endpoint = this._rearrangeEndpoints(endpoint);
     }
     if (endpoint) {
       endpoint.forEach(item => this._appendModelItem(item, target));
@@ -750,7 +750,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
    * @param {EndpointItem[]} endpoints
    * @return {EndpointItem[]}
    */
-  _sortEndpoints(endpoints) {
+  _rearrangeEndpoints(endpoints) {
     if (!endpoints) {
       return null;
     }

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -933,7 +933,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     const parts = tmpPath.split('/');
     let indent = 0;
     target._basePaths[target._basePaths.length] = path;
-    if (parts.length > 1) {
+    if (parts.length > 1 && !this.renderFullPaths) {
       const lowerParts = parts.slice(0, parts.length - 1);
       if (lowerParts.length) {
         for (let i = lowerParts.length - 1; i >= 0; i--) {
@@ -952,7 +952,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     }
     if (!name) {
       result.renderPath = false;
-      if (indent > 0 && !this.renderFullPaths) {
+      if (indent > 0) {
         try {
           name = computePathName(path, parts, indent, target._basePaths);
         } catch (_) {
@@ -970,7 +970,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     const methods = operations.map(op => this._createOperationModel(op));
     result.label = String(name);
     result.id = id;
-    result.indent = this.renderFullPaths ? 0 : indent;
+    result.indent = indent;
     result.methods = methods;
     target.endpoints.push(result);
   }

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -257,6 +257,11 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
        * No overview as a separated element. Overview can be seen by clicking the endpoint label.
        */
       noOverview: { type: Boolean },
+      /**
+       * When set, avoiids truncating and indentation of endpoint paths.
+       * Instead, the full path for each endpoint will be rendered.
+       */
+      renderFullPaths: { type: Boolean },
     };
   }
 
@@ -455,6 +460,20 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     return this.__sortEndpoints;
   }
 
+  set renderFullPaths(value) {
+    const old = this._renderFullPaths;
+    if (old === value) {
+      return;
+    }
+    this._renderFullPaths = value;
+    this.requestUpdate('renderFullPaths', old);
+    this.__amfChanged(this.amf);
+  }
+
+  get renderFullPaths() {
+    return this._renderFullPaths;
+  }
+
   constructor() {
     super();
 
@@ -471,6 +490,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     this._openedOperations = [];
     this._updatedOpenedOperations = true;
     this.noOverview = false;
+    this.renderFullPaths = false;
 
     this._navigationChangeHandler = this._navigationChangeHandler.bind(this);
     this._focusHandler = this._focusHandler.bind(this);
@@ -932,7 +952,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     }
     if (!name) {
       result.renderPath = false;
-      if (indent > 0) {
+      if (indent > 0 && !this.renderFullPaths) {
         try {
           name = computePathName(path, parts, indent, target._basePaths);
         } catch (_) {
@@ -950,7 +970,7 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     const methods = operations.map(op => this._createOperationModel(op));
     result.label = String(name);
     result.id = id;
-    result.indent = indent;
+    result.indent = this.renderFullPaths ? 0 : indent;
     result.methods = methods;
     target.endpoints.push(result);
   }

--- a/src/ApiNavigation.js
+++ b/src/ApiNavigation.js
@@ -441,6 +441,20 @@ export class ApiNavigation extends AmfHelperMixin(LitElement) {
     this._items = null;
   }
 
+  set sortEndpoints(value) {
+    const old = this.__sortEndpoints;
+    if (old === value) {
+      return;
+    }
+    this.__sortEndpoints = value;
+    this.requestUpdate('sortEndpoints', old);
+    this.__amfChanged(this.amf);
+  }
+
+  get sortEndpoints() {
+    return this.__sortEndpoints;
+  }
+
   constructor() {
     super();
 

--- a/test/api-navigation.test.js
+++ b/test/api-navigation.test.js
@@ -1287,7 +1287,7 @@ describe('<api-navigation>', () => {
         element.renderFullPaths = true;
         element.endpointsOpened = true;
         await aTimeout(50);
-        const renderedPath = element.shadowRoot.querySelectorAll('.list-item.endpoint')[2].innerText.split('\n').join('');
+        const renderedPath = element.shadowRoot.querySelectorAll('.list-item.endpoint')[2].textContent.split('\n').join('').trim();
         assert.equal(renderedPath, '/files/{fileId}/copy');
       });
 

--- a/test/api-navigation.test.js
+++ b/test/api-navigation.test.js
@@ -425,6 +425,32 @@ describe('<api-navigation>', () => {
         assert.equal(endpoint.path, expected[i][pathKey])
       );
     });
+
+
+    it('should sort after setting sortEndpoints property', async () => {
+      element = await modelFixture(amf);
+      await nextFrame();
+      let elementEndpointPaths = element._endpoints.map(endpoint => endpoint.path);
+      const expectedPaths = expected.map(endpoint => endpoint[pathKey]);
+      assert.notSameDeepOrderedMembers(elementEndpointPaths, expectedPaths);
+      element.sortEndpoints = true;
+      await nextFrame();
+      elementEndpointPaths = element._endpoints.map(endpoint => endpoint.path);
+      assert.sameDeepOrderedMembers(elementEndpointPaths, expectedPaths);
+    });
+
+    it('should unsort after toggling sortEndpoints property off', async () => {
+      element = await modelFixture(amf);
+      element.sortEndpoints = true;
+      await nextFrame();
+      let elementEndpointPaths = element._endpoints.map(endpoint => endpoint.path);
+      const expectedPaths = expected.map(endpoint => endpoint[pathKey]);
+      assert.sameDeepOrderedMembers(elementEndpointPaths, expectedPaths);
+      element.sortEndpoints = false;
+      await nextFrame();
+      elementEndpointPaths = element._endpoints.map(endpoint => endpoint.path);
+      assert.notSameDeepOrderedMembers(elementEndpointPaths, expectedPaths);
+    });
   });
 
   describe('Navigation events', () => {

--- a/test/api-navigation.test.js
+++ b/test/api-navigation.test.js
@@ -1287,8 +1287,15 @@ describe('<api-navigation>', () => {
         element.renderFullPaths = true;
         element.endpointsOpened = true;
         await aTimeout(50);
-        const renderedPath = element.shadowRoot.querySelectorAll('.list-item.endpoint')[2].innerText;
+        const renderedPath = element.shadowRoot.querySelectorAll('.list-item.endpoint')[2].innerText.split('\n').join('');
         assert.equal(renderedPath, '/files/{fileId}/copy');
+      });
+
+      it('does not indent any endpoint', async () => {
+        element.renderFullPaths = true;
+        element.endpointsOpened = true;
+        await aTimeout(50);
+        element._endpoints.forEach(endpoint => assert.equal(endpoint.indent, 0));
       });
     });
   });

--- a/test/api-navigation.test.js
+++ b/test/api-navigation.test.js
@@ -43,7 +43,7 @@ describe('<api-navigation>', () => {
    */
   async function sortedFixture() {
     return fixture(
-      html`<api-navigation sortEndpoints></api-navigation>`
+      html`<api-navigation rearrangeEndpoints></api-navigation>`
     );
   }
 
@@ -381,8 +381,8 @@ describe('<api-navigation>', () => {
       assert.equal(element.selectedType, 'endpoint');
     });
 
-    it('sortEndpoints is not true by default', () => {
-      assert.isNotTrue(element.sortEndpoints);
+    it('rearrangeEndpoints is not true by default', () => {
+      assert.isNotTrue(element.rearrangeEndpoints);
     });
   });
 
@@ -414,7 +414,7 @@ describe('<api-navigation>', () => {
     });
 
     it('should sort endpoints', () => {
-      const sorted = element._sortEndpoints(dataSet);
+      const sorted = element._rearrangeEndpoints(dataSet);
       assert.sameDeepOrderedMembers(sorted, expected);
     });
 
@@ -427,26 +427,26 @@ describe('<api-navigation>', () => {
     });
 
 
-    it('should sort after setting sortEndpoints property', async () => {
+    it('should sort after setting rearrangeEndpoints property', async () => {
       element = await modelFixture(amf);
       await nextFrame();
       let elementEndpointPaths = element._endpoints.map(endpoint => endpoint.path);
       const expectedPaths = expected.map(endpoint => endpoint[pathKey]);
       assert.notSameDeepOrderedMembers(elementEndpointPaths, expectedPaths);
-      element.sortEndpoints = true;
+      element.rearrangeEndpoints = true;
       await nextFrame();
       elementEndpointPaths = element._endpoints.map(endpoint => endpoint.path);
       assert.sameDeepOrderedMembers(elementEndpointPaths, expectedPaths);
     });
 
-    it('should unsort after toggling sortEndpoints property off', async () => {
+    it('should unsort after toggling rearrangeEndpoints property off', async () => {
       element = await modelFixture(amf);
-      element.sortEndpoints = true;
+      element.rearrangeEndpoints = true;
       await nextFrame();
       let elementEndpointPaths = element._endpoints.map(endpoint => endpoint.path);
       const expectedPaths = expected.map(endpoint => endpoint[pathKey]);
       assert.sameDeepOrderedMembers(elementEndpointPaths, expectedPaths);
-      element.sortEndpoints = false;
+      element.rearrangeEndpoints = false;
       await nextFrame();
       elementEndpointPaths = element._endpoints.map(endpoint => endpoint.path);
       assert.notSameDeepOrderedMembers(elementEndpointPaths, expectedPaths);

--- a/test/api-navigation.test.js
+++ b/test/api-navigation.test.js
@@ -1271,6 +1271,26 @@ describe('<api-navigation>', () => {
         });
       });
     });
+
+    describe('renderFullPaths', () => {
+      let amf;
+      let element;
+
+      beforeEach(async () => {
+        amf = await AmfLoader.load(item[1]);
+        element = await basicFixture();
+        element.amf = amf;
+        await nextFrame();
+      });
+
+      it('renders full paths when renderFullPaths is set', async () => {
+        element.renderFullPaths = true;
+        element.endpointsOpened = true;
+        await aTimeout(50);
+        const renderedPath = element.shadowRoot.querySelectorAll('.list-item.endpoint')[2].innerText;
+        assert.equal(renderedPath, '/files/{fileId}/copy');
+      });
+    });
   });
 
   describe('a11y', () => {

--- a/test/api-navigation.test.js
+++ b/test/api-navigation.test.js
@@ -41,9 +41,9 @@ describe('<api-navigation>', () => {
   /**
    * @returns {Promise<ApiNavigation>}
    */
-  async function arrangedFixture() {
+  async function sortedFixture() {
     return fixture(
-      html`<api-navigation rearrangeEndpoints></api-navigation>`
+      html`<api-navigation sortEndpoints></api-navigation>`
     );
   }
 
@@ -381,12 +381,12 @@ describe('<api-navigation>', () => {
       assert.equal(element.selectedType, 'endpoint');
     });
 
-    it('rearrangeEndpoints is not true by default', () => {
-      assert.isNotTrue(element.rearrangeEndpoints);
+    it('sortEndpoints is not true by default', () => {
+      assert.isNotTrue(element.sortEndpoints);
     });
   });
 
-  describe('Rearranging endpoint', () => {
+  describe('Sorting endpoints', () => {
     let element;
     let amf;
 
@@ -401,24 +401,24 @@ describe('<api-navigation>', () => {
     ];
 
     const expected = [
-      { [pathKey]: '/transactions' },
-      { [pathKey]: '/transactions/:txId' },
-      { [pathKey]: '/billing' },
       { [pathKey]: '/accounts' },
       { [pathKey]: '/accounts/:accountId' },
+      { [pathKey]: '/billing' },
+      { [pathKey]: '/transactions' },
+      { [pathKey]: '/transactions/:txId' },
     ];
 
     beforeEach(async () => {
-      element = await arrangedFixture();
+      element = await sortedFixture();
       amf = await AmfLoader.load(false, 'rearrange-api');
     });
 
-    it('should rearrange endpoints', () => {
-      const rearranged = element._rearrangeEndpoints(dataSet);
-      assert.sameDeepOrderedMembers(rearranged, expected);
+    it('should sort endpoints', () => {
+      const sorted = element._sortEndpoints(dataSet);
+      assert.sameDeepOrderedMembers(sorted, expected);
     });
 
-    it('should have endpoints rearranged', () => {
+    it('should have endpoints sorted', () => {
       element.amf = amf;
 
       element._endpoints.forEach((endpoint, i) =>
@@ -1120,7 +1120,7 @@ describe('<api-navigation>', () => {
 
       beforeEach(async () => {
         element = await operationsOpenedFixture(amf, true);
-        await aTimeout()
+        await aTimeout(0);
       });
 
       it('should expand all operations when operationsOpened', () => {


### PR DESCRIPTION
- Remove deprecated `rearrangeEndpoints` property
- Add `sortEndpoints` property
- When `sortEndpoints` is turned on, endpoints will be sorted alphabetically based on their path
- Add `renderFullPaths` property
- When `renderFullPaths` is set, endpoints are displayed with their full path (if the endpoint does not have a display name set). No indentation is applied